### PR TITLE
[#40] 댓글 기능 구현

### DIFF
--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -22,14 +22,15 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    // Todo 스크립트가 아직 최적화되지 않은 관계로 rootId를 마음대로 구현한 상태, 추후 수정 예정
     @Operation(summary = "댓글 작성 API")
     @Parameters({
             @Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
-            @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true)})
+            @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true),
+            @Parameter(name = "rootId", description = "부모 댓글의 id", in = ParameterIn.QUERY, required = true)})
     @PostMapping(value = "/posts/{postId}/comment")
-    public SuccessResponse addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") long userId, @RequestParam("content") String content) {
-        Comment comment = commentService.addComment(postId, userId, content);
-
+    public SuccessResponse addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam("content") String content, @RequestParam Long rootId) {
+        Comment comment = commentService.addComment(postId, userId, rootId, content);
         return new SuccessResponse<>(comment);
     }
 }

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -1,0 +1,32 @@
+package flab.project.controller;
+
+import flab.project.config.baseresponse.SuccessResponse;
+import flab.project.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 작성 API")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
+            @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true)})
+    @PostMapping(value = "/posts/{postId}/comment")
+    public SuccessResponse addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") long userId, @RequestParam("content") String content) {
+        return commentService.addComment(postId, userId, content);
+    }
+}

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
             @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true),
             @Parameter(name = "rootId", description = "부모 댓글의 id", in = ParameterIn.QUERY, required = true)})
     @PostMapping(value = "/posts/{postId}/comment")
-    public SuccessResponse addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam("content") String content, @RequestParam Long rootId) {
+    public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam("content") String content, @RequestParam Long rootId) {
         Comment comment = commentService.addComment(postId, userId, rootId, content);
         return new SuccessResponse<>(comment);
     }

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -22,14 +22,13 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    // Todo 스크립트가 아직 최적화되지 않은 관계로 rootId를 마음대로 구현한 상태, 추후 수정 예정
     @Operation(summary = "댓글 작성 API")
     @Parameters({
             @Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
             @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true),
             @Parameter(name = "rootId", description = "부모 댓글의 id", in = ParameterIn.QUERY, required = true)})
     @PostMapping(value = "/posts/{postId}/comment")
-    public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam("content") String content, @RequestParam Long rootId) {
+    public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam(value = "rootId", required = false) Long rootId, @RequestParam("content") String content) {
         Comment comment = commentService.addComment(postId, userId, rootId, content);
         return new SuccessResponse<>(comment);
     }

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -23,8 +23,6 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    // Todo 토론 게시물의 경우, 어느 진영(빨간색 or 청색)에 작성할 것인지에 따라 endPoint를 분리할 예정
-    // Todo (서버 입장에서) 최상단 댓글의 경우, rootId가 DB에 null이 있는 것이 어색하지 않으므로 회의 후, response에 null을 그대로 반환하는 식으로 수정할 예정
     @Operation(summary = "댓글 작성 API")
     @Parameters({
             @Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -22,14 +22,19 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    // Todo 토론 게시물의 경우, 어느 진영(빨간색 or 청색)에 작성할 것인지에 따라 endPoint를 분리할 예정
+    // Todo (서버 입장에서) 최상단 댓글의 경우, rootId가 DB에 null이 있는 것이 어색하지 않으므로 회의 후, response에 null을 그대로 반환하는 식으로 수정할 예정
     @Operation(summary = "댓글 작성 API")
     @Parameters({
             @Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
             @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true),
-            @Parameter(name = "rootId", description = "부모 댓글의 id", in = ParameterIn.QUERY, required = true)})
+            @Parameter(name = "parentId", description = "부모 댓글의 id", in = ParameterIn.QUERY, required = true)})
     @PostMapping(value = "/posts/{postId}/comment")
-    public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") @Positive long userId, @RequestParam(value = "rootId", required = false) Long rootId, @RequestParam("content") String content) {
-        Comment comment = commentService.addComment(postId, userId, rootId, content);
+    public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId,
+                                               @RequestParam("userId") @Positive long userId,
+                                               @RequestParam(value = "parentId", required = false) @Positive Long parentId,
+                                               @RequestParam("content") String content) {
+        Comment comment = commentService.addComment(postId, userId, parentId, content);
         return new SuccessResponse<>(comment);
     }
 }

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -1,6 +1,7 @@
 package flab.project.controller;
 
 import flab.project.config.baseresponse.SuccessResponse;
+import flab.project.data.dto.model.Comment;
 import flab.project.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,6 +28,8 @@ public class CommentController {
             @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true)})
     @PostMapping(value = "/posts/{postId}/comment")
     public SuccessResponse addComment(@PathVariable("postId") @Positive long postId, @RequestParam("userId") long userId, @RequestParam("content") String content) {
-        return commentService.addComment(postId, userId, content);
+        Comment comment = commentService.addComment(postId, userId, content);
+
+        return new SuccessResponse<>(comment);
     }
 }

--- a/src/main/java/flab/project/controller/CommentController.java
+++ b/src/main/java/flab/project/controller/CommentController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -33,7 +34,7 @@ public class CommentController {
     public SuccessResponse<Comment> addComment(@PathVariable("postId") @Positive long postId,
                                                @RequestParam("userId") @Positive long userId,
                                                @RequestParam(value = "parentId", required = false) @Positive Long parentId,
-                                               @RequestParam("content") String content) {
+                                               @RequestParam("content") @NotBlank String content) {
         Comment comment = commentService.addComment(postId, userId, parentId, content);
         return new SuccessResponse<>(comment);
     }

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -1,16 +1,14 @@
 package flab.project.data.dto.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Builder
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 @Schema(description = "댓글 Dto")
 public class Comment {
 
@@ -23,9 +21,9 @@ public class Comment {
     @Schema(example = "1")
     private long commentId;
 
-    @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글", nullable = true)
+    @Schema(description = "대댓글이 존재할 경우, 가장 최상단의 댓글", example = "1", nullable = true)
     @Setter
-    private Long rootId;
+    private Long parentId;
 
     @Schema(example = "화이팅 합시다!")
     private String content;
@@ -36,6 +34,15 @@ public class Comment {
     @Schema(example = "1400", defaultValue = "0")
     private long likeCount;
 
-    @Schema(example = "14", defaultValue = "0")
-    private long commentCount;
+    @Schema(description = "대댓글의 개수", example = "14", defaultValue = "0")
+    private long childrenCount;
+
+    @Builder
+    public Comment(long postId, long userId, Long parentId, String content) {
+        this.postId = postId;
+        this.userId = userId;
+        this.parentId = parentId;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -5,32 +5,34 @@ import lombok.Getter;
 
 import lombok.Builder;
 
+import java.sql.Timestamp;
+
 @Builder
 @Getter
 @Schema(description = "댓글 Dto")
 public class Comment {
 
     @Schema(example = "1")
-    protected long postId;
+    private long postId;
 
     @Schema(example = "1")
-    protected long userId;
+    private long userId;
 
     @Schema(example = "1")
-    protected long commentId;
+    private long commentId;
 
     @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글")
-    protected long rootId;
+    private long rootId;
 
     @Schema(example = "화이팅 합시다!")
-    protected String content;
+    private String content;
 
-    @Schema(example = "방금 전")
-    protected String createTime;
+    @Schema(example = "2023-09-19 12:00:00")
+    private Timestamp createdAt;
 
     @Schema(example = "1400", defaultValue = "0")
-    protected long likeCount;
+    private long likeCount;
 
     @Schema(example = "14", defaultValue = "0")
-    protected long commentCount;
+    private long commentCount;
 }

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -23,13 +23,13 @@ public class Comment {
     private long commentId;
 
     @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글")
-    private long rootId;
+    private Long rootId;
 
     @Schema(example = "화이팅 합시다!")
     private String content;
 
     @Schema(example = "2023-09-19 12:00:00")
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     @Schema(example = "1400", defaultValue = "0")
     private long likeCount;

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +24,7 @@ public class Comment {
     private long commentId;
 
     @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글", nullable = true)
+    @Setter
     private Long rootId;
 
     @Schema(example = "화이팅 합시다!")
@@ -36,8 +38,4 @@ public class Comment {
 
     @Schema(example = "14", defaultValue = "0")
     private long commentCount;
-
-    public void setRootId(Long rootId) {
-        this.rootId = rootId;
-    }
 }

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -22,7 +22,7 @@ public class Comment {
     @Schema(example = "1")
     private long commentId;
 
-    @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글")
+    @Schema(example = "1", description = "대댓글이 존재할 경우, 가장 최상단의 댓글", nullable = true)
     private Long rootId;
 
     @Schema(example = "화이팅 합시다!")
@@ -36,4 +36,8 @@ public class Comment {
 
     @Schema(example = "14", defaultValue = "0")
     private long commentCount;
+
+    public void setRootId(Long rootId) {
+        this.rootId = rootId;
+    }
 }

--- a/src/main/java/flab/project/data/dto/model/Comment.java
+++ b/src/main/java/flab/project/data/dto/model/Comment.java
@@ -1,14 +1,15 @@
 package flab.project.data.dto.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.sql.Timestamp;
 
 @Builder
 @Getter
+@AllArgsConstructor
 @Schema(description = "댓글 Dto")
 public class Comment {
 

--- a/src/main/java/flab/project/mapper/CommentMapper.java
+++ b/src/main/java/flab/project/mapper/CommentMapper.java
@@ -7,6 +7,5 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface CommentMapper {
 
-    // Todo comment-mapper.xml에 대댓글 개수를 나타내는 commentCount(이름 변경 예정) 필드 추가 예정
     void addComment(@Param("comment") Comment comment);
 }

--- a/src/main/java/flab/project/mapper/CommentMapper.java
+++ b/src/main/java/flab/project/mapper/CommentMapper.java
@@ -7,5 +7,6 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface CommentMapper {
 
-    Comment addComment(@Param("comment") Comment comment);
+    // Todo comment-mapper.xml에 대댓글 개수를 나타내는 commentCount(이름 변경 예정) 필드 추가 예정
+    void addComment(@Param("comment") Comment comment);
 }

--- a/src/main/java/flab/project/mapper/CommentMapper.java
+++ b/src/main/java/flab/project/mapper/CommentMapper.java
@@ -1,0 +1,11 @@
+package flab.project.mapper;
+
+import flab.project.data.dto.model.Comment;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface CommentMapper {
+
+    Comment addComment(@Param("comment") Comment comment);
+}

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -1,0 +1,26 @@
+package flab.project.service;
+
+import flab.project.config.baseresponse.SuccessResponse;
+import flab.project.data.dto.model.Comment;
+import flab.project.mapper.CommentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+
+    private final CommentMapper commentMapper;
+
+    public SuccessResponse<Comment> addComment (long postId, long userId, String content) {
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .content(content)
+                .build();
+
+        commentMapper.addComment(comment);
+
+        return new SuccessResponse<>(comment);
+    }
+}

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -13,18 +13,32 @@ public class CommentService {
 
     private final CommentMapper commentMapper;
 
-    public Comment addComment (long postId, long userId, String content) {
+    public Comment addComment (long postId, long userId, Long rootId, String content) {
+        Comment comment = createComment(postId, userId, content);
+
+        commentMapper.addComment(comment);
+
+        setRootId(comment, rootId);
+
+        return comment;
+    }
+
+    private Comment createComment(long postId, long userId, String content) {
         LocalDateTime todayTime = LocalDateTime.now();
 
-        Comment comment = Comment.builder()
+        return Comment.builder()
                 .postId(postId)
                 .userId(userId)
                 .content(content)
                 .createdAt(todayTime)
                 .build();
+    }
 
-        commentMapper.addComment(comment);
-
-        return comment;
+    // Todo 근데 rootId 값이 null일 경우, rootId 값이 commentId 값으로 세팅되는 걸 Swagger UI상에서 확인할 수가 없는데..
+    private void setRootId(Comment comment, Long rootId) {
+        if (rootId == null) {
+            rootId = comment.getCommentId();
+        }
+        comment.setRootId(rootId);
     }
 }

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -13,6 +13,11 @@ public class CommentService {
     private final CommentMapper commentMapper;
 
     public SuccessResponse<Comment> addComment (long postId, long userId, String content) {
+        // Todo 대댓글이 아닌 최상단 댓글을 작성할 경우, rootId를 어떻게 처리할지 세션에서 질문할 예정
+        // Todo 1) Controller에서 0인 rootId를 Service로 넘기는 방법
+        // Todo 2) rootId를 reference type으로 수정하여 null checking하는 방법
+        // Todo 그런데, 1)과 2)는 서버 입장에서 정확히 어떤 연유로 0 또는 null 값을 가지게 되었는지를 알 수 없어서 별로인 것 같음
+        // Todo 3) 최상단 댓글을 작성할 경우와 대댓글을 작성할 경우 엔드 포인트를 분리하는 방법은 어떨까?
         Comment comment = Comment.builder()
                 .postId(postId)
                 .userId(userId)

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -1,11 +1,11 @@
 package flab.project.service;
 
+import flab.project.config.exception.InvalidUserInputException;
+import flab.project.config.exception.NotFoundException;
 import flab.project.data.dto.model.Comment;
 import flab.project.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -13,32 +13,54 @@ public class CommentService {
 
     private final CommentMapper commentMapper;
 
-    public Comment addComment (long postId, long userId, Long rootId, String content) {
-        Comment comment = createComment(postId, userId, content);
+    public Comment addComment(long postId, long userId, Long parentId, String content) {
+        validateComment(postId, userId, parentId);
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .parentId(parentId)
+                .content(content)
+                .build();
+
+        if (comment == null) {
+            throw new NotFoundException("comment is not found.");
+        }
 
         commentMapper.addComment(comment);
 
-        setRootId(comment, rootId);
+        setRootId(comment, parentId);
 
         return comment;
     }
 
-    private Comment createComment(long postId, long userId, String content) {
-        LocalDateTime todayTime = LocalDateTime.now();
-
-        return Comment.builder()
-                .postId(postId)
-                .userId(userId)
-                .content(content)
-                .createdAt(todayTime)
-                .build();
+    private void validateComment(long postId, long userId, Long parentId) {
+        // Todo userId는 추후 삭제 예정이므로 합쳐서 작성
+        validatePostIdAndUserId(postId, userId);
+        validateParentId(parentId);
     }
 
-    // Todo 근데 rootId 값이 null일 경우, rootId 값이 commentId 값으로 세팅되는 걸 Swagger UI상에서 확인할 수가 없는데..
-    private void setRootId(Comment comment, Long rootId) {
-        if (rootId == null) {
-            rootId = comment.getCommentId();
+    private void validatePostIdAndUserId(long postId, long userId) {
+        if (postId <= 0) {
+            throw new InvalidUserInputException("Invalid postId.");
         }
-        comment.setRootId(rootId);
+
+        if (userId <= 0) {
+            throw new InvalidUserInputException("Invalid userId.");
+        }
+    }
+
+    private void validateParentId(Long parentId) {
+        if (parentId <= 0) {
+            throw new InvalidUserInputException("Invalid parentId.");
+        }
+    }
+
+    // Todo (CommentController 26L) parentId에 commentId를 넣지 않고, null을 그대로 넣는 방식으로 회의 후 수정 예정 / builder에 rootId 추가
+    private void setRootId(Comment comment, Long parentId) {
+        if (parentId == null) {
+            parentId = comment.getCommentId();
+        }
+        comment.setParentId(parentId);
     }
 }

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -1,10 +1,11 @@
 package flab.project.service;
 
-import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.data.dto.model.Comment;
 import flab.project.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -12,20 +13,18 @@ public class CommentService {
 
     private final CommentMapper commentMapper;
 
-    public SuccessResponse<Comment> addComment (long postId, long userId, String content) {
-        // Todo 대댓글이 아닌 최상단 댓글을 작성할 경우, rootId를 어떻게 처리할지 세션에서 질문할 예정
-        // Todo 1) Controller에서 0인 rootId를 Service로 넘기는 방법
-        // Todo 2) rootId를 reference type으로 수정하여 null checking하는 방법
-        // Todo 그런데, 1)과 2)는 서버 입장에서 정확히 어떤 연유로 0 또는 null 값을 가지게 되었는지를 알 수 없어서 별로인 것 같음
-        // Todo 3) 최상단 댓글을 작성할 경우와 대댓글을 작성할 경우 엔드 포인트를 분리하는 방법은 어떨까?
+    public Comment addComment (long postId, long userId, String content) {
+        LocalDateTime todayTime = LocalDateTime.now();
+
         Comment comment = Comment.builder()
                 .postId(postId)
                 .userId(userId)
                 .content(content)
+                .createdAt(todayTime)
                 .build();
 
         commentMapper.addComment(comment);
 
-        return new SuccessResponse<>(comment);
+        return comment;
     }
 }

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -1,7 +1,6 @@
 package flab.project.service;
 
 import flab.project.config.exception.InvalidUserInputException;
-import flab.project.config.exception.NotFoundException;
 import flab.project.data.dto.model.Comment;
 import flab.project.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +22,12 @@ public class CommentService {
                 .content(content)
                 .build();
 
-        if (comment == null) {
-            throw new NotFoundException("comment is not found.");
-        }
+        // Todo comment가 null이라는 건 너무 추상적으로 이해가 되는데.., 댓글일 경우 null을 가지는 parentId + Primitive Type인 postId 및 userId를 제외하고는 content에 null이 담겼을 경우밖에 없을 것 같은데?
+        // Todo 이건 controller에서 해줄 수 있는 검증인데, service에서도 존재하지 않는 댓글이라는 어색한 context로 검증을 해줘야 할까?
 
         commentMapper.addComment(comment);
 
-        setRootId(comment, parentId);
+        // setRootId(comment, parentId);
 
         return comment;
     }
@@ -51,16 +49,16 @@ public class CommentService {
     }
 
     private void validateParentId(Long parentId) {
-        if (parentId <= 0) {
+        if (parentId != null && parentId <= 0) {
             throw new InvalidUserInputException("Invalid parentId.");
         }
     }
 
-    // Todo (CommentController 26L) parentId에 commentId를 넣지 않고, null을 그대로 넣는 방식으로 회의 후 수정 예정 / builder에 rootId 추가
-    private void setRootId(Comment comment, Long parentId) {
-        if (parentId == null) {
-            parentId = comment.getCommentId();
-        }
-        comment.setParentId(parentId);
-    }
+    // Todo (CommentController 26L) parentId에 commentId를 넣지 않고, null을 그대로 넣는 방식으로 회의 후 수정 예정 / builder에 parentId 추가
+    // private void setRootId(Comment comment, Long parentId) {
+    //    if (parentId == null) {
+    //        parentId = comment.getCommentId();
+    //    }
+    //    comment.setParentId(parentId);
+    // }
 }

--- a/src/main/java/flab/project/service/CommentService.java
+++ b/src/main/java/flab/project/service/CommentService.java
@@ -22,12 +22,7 @@ public class CommentService {
                 .content(content)
                 .build();
 
-        // Todo comment가 null이라는 건 너무 추상적으로 이해가 되는데.., 댓글일 경우 null을 가지는 parentId + Primitive Type인 postId 및 userId를 제외하고는 content에 null이 담겼을 경우밖에 없을 것 같은데?
-        // Todo 이건 controller에서 해줄 수 있는 검증인데, service에서도 존재하지 않는 댓글이라는 어색한 context로 검증을 해줘야 할까?
-
         commentMapper.addComment(comment);
-
-        // setRootId(comment, parentId);
 
         return comment;
     }
@@ -53,12 +48,4 @@ public class CommentService {
             throw new InvalidUserInputException("Invalid parentId.");
         }
     }
-
-    // Todo (CommentController 26L) parentId에 commentId를 넣지 않고, null을 그대로 넣는 방식으로 회의 후 수정 예정 / builder에 parentId 추가
-    // private void setRootId(Comment comment, Long parentId) {
-    //    if (parentId == null) {
-    //        parentId = comment.getCommentId();
-    //    }
-    //    comment.setParentId(parentId);
-    // }
 }

--- a/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
+++ b/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="flab.project.mapper.VoteMapper">
+
+    <insert id="addComment" parameterType="flab.project.data.dto.model.Comment" useGeneratedKeys="true" keyProperty="commentId">
+        INSERT INTO CHOICE(post_id, user_id, content)
+        VALUES (#{postId}, #{userId}, #{content})
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
+++ b/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="flab.project.mapper.VoteMapper">
+<mapper namespace="flab.project.mapper.CommentMapper">
 
     <insert id="addComment" parameterType="flab.project.data.dto.model.Comment" useGeneratedKeys="true" keyProperty="commentId">
-        INSERT INTO CHOICE(post_id, user_id, content)
-        VALUES (#{postId}, #{userId}, #{content})
+        INSERT INTO Comment(post_id, user_id, content)
+        VALUES (#{comment.postId}, #{comment.userId}, #{comment.content})
     </insert>
 
 </mapper>

--- a/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
+++ b/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="flab.project.mapper.CommentMapper">
 
-    <insert id="addComment" parameterType="flab.project.data.dto.model.Comment" useGeneratedKeys="true" keyProperty="commentId">
+    <insert id="addComment" useGeneratedKeys="true" keyProperty="commentId">
         INSERT INTO Comment(post_id, user_id, content)
         VALUES (#{comment.postId}, #{comment.userId}, #{comment.content})
     </insert>

--- a/src/test/java/flab/project/controller/CommentControllerTest.java
+++ b/src/test/java/flab/project/controller/CommentControllerTest.java
@@ -200,4 +200,27 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
                 .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
+
+    // Todo @NotBlank가 null + "" + " "을 허용하지 않던데..
+    @DisplayName("댓글을 작성할 때, content가 공백일 경우 InvalidUserInputException을 반환한다.")
+    @Test
+    void addComment_nonNullableContent() throws Exception {
+        // given
+        long postId = 1L;
+        long userId = 1L;
+        Long parentId = null;
+        String content = " ";
+
+        // when & then
+        mockMvc.perform(
+                        post("/posts/{postId}/comment", postId)
+                                .param("userId", String.valueOf(userId))
+                                .param("content", content)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.INVALID_USER_INPUT.isSuccess()))
+                .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
+                .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
+    }
 }

--- a/src/test/java/flab/project/controller/CommentControllerTest.java
+++ b/src/test/java/flab/project/controller/CommentControllerTest.java
@@ -88,28 +88,6 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.message").value(ResponseEnum.SUCCESS.getMessage()));
     }
 
-    @DisplayName("댓글을 작성할 때, postId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
-    @Test
-    void addComment_invalidPostId() throws Exception {
-        // given
-        long negativePostId = -1L;
-        long userId = 1L;
-        Long parentId = null;
-        String content = "안녕하세요.";
-
-        // when & then
-        mockMvc.perform(
-                        post("/posts/{postId}/comment", negativePostId)
-                                .param("userId", String.valueOf(userId))
-                                .param("content", content)
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.INVALID_USER_INPUT.isSuccess()))
-                .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
-                .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
-    }
-
     @DisplayName("대댓글을 작성할 때, postId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
     @Test
     void addReply_invalidPostId() throws Exception {
@@ -124,28 +102,6 @@ public class CommentControllerTest {
                 post("/posts/{postId}/comment", negativePostId)
                         .param("userId", String.valueOf(userId))
                         .param("parentId", String.valueOf(parentId))
-                        .param("content", content)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.INVALID_USER_INPUT.isSuccess()))
-                .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
-                .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
-    }
-
-    @DisplayName("댓글을 작성할 때, userId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
-    @Test
-    void addComment_invalidUserId() throws Exception {
-        // given
-        long postId = 1L;
-        long negativeUserId = -1L;
-        Long parentId = null;
-        String content = "안녕하세요.";
-
-        // when & then
-        mockMvc.perform(
-                post("/posts/{postId}/comment", postId)
-                        .param("userId", String.valueOf(negativeUserId))
                         .param("content", content)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())

--- a/src/test/java/flab/project/controller/CommentControllerTest.java
+++ b/src/test/java/flab/project/controller/CommentControllerTest.java
@@ -1,0 +1,95 @@
+package flab.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import flab.project.config.baseresponse.ResponseEnum;
+import flab.project.config.baseresponse.SuccessResponse;
+import flab.project.service.CommentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CommentController.class)
+public class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CommentService commentService;
+
+    @DisplayName("댓글을 작성할 수 있다.")
+    @Test
+    void addComment() throws Exception {
+        // given
+        long postId = 1L;
+        long userId = 1L;
+        String content = "안녕하세요.";
+
+        given(commentService.addComment(postId, userId, content)).willReturn(new SuccessResponse<>());
+
+        // when & then
+        mockMvc.perform(
+                        post("/posts/{postId}/comment", postId)
+                                .param("userId", String.valueOf(userId))
+                                .param("content", content)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.SUCCESS.isSuccess()))
+                .andExpect(jsonPath("$.code").value(ResponseEnum.SUCCESS.getCode()))
+                .andExpect(jsonPath("$.message").value(ResponseEnum.SUCCESS.getMessage()));
+    }
+
+    @DisplayName("댓글을 작성하려고 할 때, postId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
+    @Test
+    void addComment_invalidPostId() throws Exception {
+        // given
+        long negativePostId = -1L;
+        long userId = 1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        mockMvc.perform(
+                        post("/posts/{postId}/comment", negativePostId)
+                                .param("userId", String.valueOf(userId))
+                                .param("content", content)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.INVALID_USER_INPUT.isSuccess()))
+                .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
+                .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
+    }
+
+    @DisplayName("댓글을 작성하려고 할 때, userId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
+    @Test
+    void addComment_invalidUserId() throws Exception {
+        // given
+        long postId = 1L;
+        long negativeUserId = -1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        mockMvc.perform(
+                post("/posts/{postId}/comment", postId)
+                        .param("userId", String.valueOf(negativeUserId))
+                        .param("content", content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(ResponseEnum.INVALID_USER_INPUT.isSuccess()))
+                .andExpect(jsonPath("$.code").value(ResponseEnum.INVALID_USER_INPUT.getCode()))
+                .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
+    }
+}

--- a/src/test/java/flab/project/controller/CommentControllerTest.java
+++ b/src/test/java/flab/project/controller/CommentControllerTest.java
@@ -178,9 +178,9 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @DisplayName("대댓글을 작성할 때, rootId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
+    @DisplayName("대댓글을 작성할 때, parentId가 양수가 아닐 경우 InvalidUserInputException을 반환한다.")
     @Test
-    void addComment_invalidRootId() throws Exception {
+    void addComment_invalidParentId() throws Exception {
         // given
         long postId = 1L;
         long userId = 1L;
@@ -201,7 +201,6 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    // Todo @NotBlank가 null + "" + " "을 허용하지 않던데..
     @DisplayName("댓글을 작성할 때, content가 공백일 경우 InvalidUserInputException을 반환한다.")
     @Test
     void addComment_nonNullableContent() throws Exception {

--- a/src/test/java/flab/project/service/CommentServiceTest.java
+++ b/src/test/java/flab/project/service/CommentServiceTest.java
@@ -1,0 +1,139 @@
+package flab.project.service;
+
+import flab.project.config.exception.InvalidUserInputException;
+import flab.project.data.dto.model.Comment;
+import flab.project.mapper.CommentMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+
+    @InjectMocks
+    CommentService commentService;
+    @Mock
+    CommentMapper commentMapper;
+
+    @DisplayName("댓글을 작성할 수 있다.")
+    @Test
+    void addComment_isComment() {
+        // given
+        long postId = 1L;
+        long userId = 1L;
+        Long parentId = null;
+        String content = "안녕하세요.";
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .parentId(parentId)
+                .content(content)
+                .build();
+
+        // when
+        commentService.addComment(postId, userId, parentId, content);
+
+        // then
+        then(commentMapper).should().addComment(comment);
+    }
+
+    @DisplayName("대댓글을 작성할 수 있다.")
+    @Test
+    void addComment_isReply() {
+        // given
+        long postId = 1L;
+        long userId = 1L;
+        Long parentId = 1L;
+        String content = "안녕하세요.";
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .parentId(parentId)
+                .content(content)
+                .build();
+
+        // when
+        commentService.addComment(postId, userId, parentId, content);
+
+        // then
+        then(commentMapper).should().addComment(comment);
+    }
+
+    @DisplayName("댓글을 작성할 때, postId가 양수가 아니라면 InvalidUserInputException을 반환한다.")
+    @Test
+    void addComment_invalidPostId() {
+        // given
+        long negativePostId = -1L;
+        long userId = 1L;
+        Long parentId = null;
+        String content = "안녕하세요.";
+
+        // when & then
+        assertThatThrownBy(() -> commentService.addComment(negativePostId, userId, parentId, content))
+                .isInstanceOf(InvalidUserInputException.class);
+    }
+
+    @DisplayName("대댓글을 작성할 때, postId가 양수가 아니라면 InvalidUserInputException을 반환한다.")
+    @Test
+    void addReply_invalidPostId() {
+        // given
+        long negativePostId = -1L;
+        long userId = 1L;
+        Long parentId = 1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        assertThatThrownBy(() -> commentService.addComment(negativePostId, userId, parentId, content))
+                .isInstanceOf(InvalidUserInputException.class);
+    }
+
+    @DisplayName("댓글을 작성할 때, userId가 양수가 아니라면 InvalidUserInputException을 반환한다.")
+    @Test
+    void addComment_invalidUserId() {
+        // given
+        long postId = 1L;
+        long negativeUserId = -1L;
+        Long parentId = 1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        assertThatThrownBy(() -> commentService.addComment(postId, negativeUserId, parentId, content))
+                .isInstanceOf(InvalidUserInputException.class);
+    }
+
+    @DisplayName("대댓글을 작성할 때, userId가 양수가 아니라면 InvalidUserInputException을 반환한다.")
+    @Test
+    void addReply_invalidUserId() {
+        // given
+        long postId = 1L;
+        long negativeUserId = -1L;
+        Long parentId = 1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        assertThatThrownBy(() -> commentService.addComment(postId, negativeUserId, parentId, content))
+                .isInstanceOf(InvalidUserInputException.class);
+    }
+
+    @DisplayName("대댓글을 작성할 때, parentId가 양수가 아니라면 InvalidUserInputException을 반환한다.")
+    @Test
+    void addReply_invalidParentId() {
+        // given
+        long postId = 1L;
+        long userId = 1L;
+        Long negativeParentId = -1L;
+        String content = "안녕하세요.";
+
+        // when & then
+        assertThatThrownBy(() -> commentService.addComment(postId, userId, negativeParentId,content))
+                .isInstanceOf(InvalidUserInputException.class);
+    }
+}


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #40 댓글 달기 API 

## 📃 작업 사항
- 댓글 달기 기능 구현

## ✔️ 체크 포인트
### (2023.10.07)
### Controller
1. 토론 게시물의 경우, 어느 진영에 댓글을 작성할 것인지에 따라 end-point를 분리할 예정
2. 서버 입장에서 최상단 댓글의 경우, rootId가 DB에 null이 있는 것이 어색하지 않으므로 response에 null을 반환하는 식으로 **프론트엔드 분**과 대화를 나눈 뒤, 수정할 예정
3. rootId -> parentId로 이름 수정 예정
### Service
1. builder <-> constructor
- 현재 형태는 builder를 다른 메서드로 뺀 형태인데, 이 형태는 builder의 이점을 살리지 못한다고 판단
 - 즉, 현재 builder 형태와 매개변수 생성자와 다를 것이 없음
### ControllerTest
1. null -> "값이 없음을 은유적으로 표현" -> 따라서 실제로 값을 넣어주지 않아도 동일한 결과값을 낼 수 있음
### ServiceTest
1. Diffetent Arguments -> 객체의 hashCode() 및 equals()를 통한 오류 해결
- 즉 객체를 비교할 때 equals()를 사용했을지라도 내부에서는 ==을 이용하여 비교했기 때문에, 객체를 비교할 수가 없었음