### PR TITLE
[Refactor] FanOutMessage 구조 수정

### DIFF
--- a/src/main/java/flab/project/consumer/service/NewsFeedFanOutService.java
+++ b/src/main/java/flab/project/consumer/service/NewsFeedFanOutService.java
@@ -1,7 +1,9 @@
 package flab.project.consumer.service;
 
 import flab.project.data.dto.FanOutMessage;
+import flab.project.service.FollowService;
 import flab.project.utils.NewsFeedRedisUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,8 +12,11 @@ import org.springframework.stereotype.Service;
 public class NewsFeedFanOutService {
 
     private final NewsFeedRedisUtil newsFeedRedisUtil;
+    private final FollowService followService;
 
     public void fanOut(FanOutMessage fanOutMessage) {
-        newsFeedRedisUtil.addForMultipleUsers(fanOutMessage.getFollowerIds(), fanOutMessage.getPostId());
+        List<Long> followerIds = followService.getFollowerIds(fanOutMessage.getUserId());
+
+        newsFeedRedisUtil.addForMultipleUsers(followerIds, fanOutMessage.getPostId());
     }
 }

--- a/src/main/java/flab/project/data/dto/FanOutMessage.java
+++ b/src/main/java/flab/project/data/dto/FanOutMessage.java
@@ -10,6 +10,6 @@ import java.util.List;
 @NoArgsConstructor
 public class FanOutMessage {
 
+    private long userId;
     private long postId;
-    private List<Long> followerIds;
 }

--- a/src/main/java/flab/project/service/FanOutService.java
+++ b/src/main/java/flab/project/service/FanOutService.java
@@ -4,18 +4,14 @@ import flab.project.data.dto.FanOutMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @Service
 public class FanOutService {
 
-    private final FollowService followService;
     private final RabbitMQProducer rabbitMQProducer;
 
     public void fanOut(Long userId, long postId) {
-        List<Long> followerIds = followService.getFollowerIds(userId);
-        FanOutMessage fanOutMessage = new FanOutMessage(postId, followerIds);
+        FanOutMessage fanOutMessage = new FanOutMessage(userId, postId);
 
         rabbitMQProducer.sendMessage(fanOutMessage);
     }


### PR DESCRIPTION
## 📃 작업 사항
- FanOutMessage 구조 변경.
- 기존 Message는 postId와 followerIds를 보냈음. 즉, API서버에서 followers를 미리 받아와서 FanOutServer에게 전달함.
- server가 분리됨으로써 좋은 점은 API서버에게 가해지는 부하와 fanOut을 위한 부하가 다르므로 별도의 서버로 분리하고 해당 부하에 맞춰 scale-out할 수 있다는 것이 장점인데, 그를 위해서는 follower를 가져오는 로직을 fanOutServer에게 주는 것이 옳다고 판단햇음
