### PR TITLE
[#119] 이메일 인증 코드 전송 API Swagger 작성

### DIFF
--- a/src/main/java/flab/project/config/SwaggerConfig.java
+++ b/src/main/java/flab/project/config/SwaggerConfig.java
@@ -1,12 +1,9 @@
 package flab.project.config;
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.In;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,13 +18,6 @@ public class SwaggerConfig {
                         .description("개발자의 SNS를 컨셉으로한 프로젝트입니다.(은비님 성진님 여기다가 뭐 적을지 멘트 추천점여)")
                         .version("1.0.0"))
                 .components(new Components()
-//                        .addSecuritySchemes("bearer-key",
-//                                new io.swagger.v3.oas.models.security.SecurityScheme()
-//                                        .name("Authorization")
-//                                        .type(Type.APIKEY)
-//                                        .in(In.HEADER)
-//                                        .scheme("bearer")
-//                                        .bearerFormat("JWT")));
                         .addSecuritySchemes("bearer-key", new SecurityScheme()
                                 .name("bearer-key")
                                 .type(SecurityScheme.Type.HTTP) // HTTP 방식

--- a/src/main/java/flab/project/config/baseresponse/BaseResponse.java
+++ b/src/main/java/flab/project/config/baseresponse/BaseResponse.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 @JsonPropertyOrder({"isSuccess", "code", "message"})
 public abstract class BaseResponse {
 
-    @Schema(name = "성공 여부", example = "true")
+    @Schema(description = "성공 여부", example = "true")
     private final Boolean isSuccess;
 
-    @Schema(name = "요청에 대한 결과 메세지", example = "요청에 성공하였습니다.")
+    @Schema(description = "요청에 대한 결과 메세지", example = "요청에 성공하였습니다.")
     private final String message;
 
-    @Schema(name = "요청에 대한 결과 코드", example = "1000")
+    @Schema(description = "요청에 대한 결과 코드", example = "1000")
     private final int code;
 
     protected BaseResponse(ResponseEnum status) {

--- a/src/main/java/flab/project/domain/user/controller/VerificationController.java
+++ b/src/main/java/flab/project/domain/user/controller/VerificationController.java
@@ -1,18 +1,29 @@
 package flab.project.domain.user.controller;
 
+import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.user.service.VerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
+import java.util.stream.Collectors;
+
+@Tag(name = "회원가입 API", description = "회원가입 과정에서 사용되는 API</br>" +
+        "[회원가입 전체로직](https://www.notion.so/b577233726be48ab9706381c8cbcd7ff?pvs=4)은 링크를 참고하길 바란다.")
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -20,18 +31,69 @@ public class VerificationController {
 
     private final VerificationService verificationService;
 
-    @Operation(summary = "인증코드 전송 API")
+    @ExceptionHandler(ConstraintViolationException.class)
+    public FailResponse handleConstraintViolationException(ConstraintViolationException exception) {
+        String errorMessage = exception.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining(", "));
+
+        return new FailResponse(errorMessage, 4000);
+    }
+
+    @Operation(summary = "인증코드 전송 API", description = "인증코드 전송 API이다.</br>" +
+            "유저가 전달한 email로 이메일 인증코드가 전달되며 해당 인증코드는 **인증코드 검증 API**에서 사용된다.")
     @PostMapping(value = "/verification/email")
-    public SuccessResponse sendVerificationCode(@RequestParam("address") @Email @NotBlank String email) {
+    @Parameter(
+            name = "email",
+            required = true,
+            description = "해당 email로 인증 코드가 보내진다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "이메일 인증코드 전송 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = "{" +
+                                            "\"isSuccess\": true," +
+                                            "\"code\": 1000," +
+                                            "\"message\": \"요청에 성공하였습니다.\"" +
+                                            "}"
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "올바른 이메일 형식이여야 합니다.(이메일 형식과 일치하지 않거나 이메일이 전송되지 않은 경우)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = "{" +
+                                            "\"isSuccess\": false," +
+                                            "\"code\": 4000," +
+                                            "\"message\": \"올바른 이메일 형식이여야 합니다.\"" +
+                                            "}"
+                            )
+                    )
+            ),
+    })
+    public SuccessResponse<Void> sendVerificationCode(
+            @RequestParam("email")
+            @Email(message = "올바른 이메일 형식이여야 합니다.")
+            @NotBlank(message = "올바른 이메일 형식이여야 합니다.") String email
+    ) {
         verificationService.sendVerificationCode(email);
 
-        return new SuccessResponse();
+        return new SuccessResponse<>();
     }
 
     @Operation(summary = "인증코드 검증 API")
     @Parameter(name = "code", description = "유저의 이메일에 발송된 인증코드", required = true)
     @PostMapping(value = "/verification/email/{address}")
-    public SuccessResponse checkVerificationCode(@PathVariable("address") @Email @NotBlank String email,
+    public SuccessResponse<Void> checkVerificationCode(@PathVariable("address") @Email @NotBlank String email,
                                                  @RequestParam("code") @NotBlank String code) {
         verificationService.checkVerificationCode(email, code);
 


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #119  

## 📃 작업 사항
- 이메일 인증 코드 전송 API Swagger 작성

## ☑️ Todo
- Controller 단위 ExceptionHandler를 사용했으나, 조금 더 고민하고 GlobalExceptionHandler로 수정할 예정
- Swagger의 ApiResponses에 404, 400, 500번 errorrResponse가 불필요하게 노출되고 있음. 다른 PR에서 수정할 예정
