### PR TITLE
[#129] 회원가입 관련 API Swagger 마무리

### DIFF
--- a/src/main/java/flab/project/config/SecurityConfig.java
+++ b/src/main/java/flab/project/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             .authorizeHttpRequests(authorize ->
-                authorize.requestMatchers("/users", "/send", "/login", "/verification/email/**", "/verify-username",
+                authorize.requestMatchers("/users", "/send", "/login", "/verification/email/**", "/verification/username",
                         "/swagger-ui/**",
                         "/v3/api-docs/**").permitAll()
                     .anyRequest().authenticated()

--- a/src/main/java/flab/project/domain/user/controller/SignUpController.java
+++ b/src/main/java/flab/project/domain/user/controller/SignUpController.java
@@ -66,7 +66,7 @@ public class SignUpController {
                 2. 이메일 인증 코드 확인 요청 API
                 3. 닉네임 중복 확인 요청 API
                                 
-                Reference: [참고 문서](https://www.notion.so/b577233726be48ab9706381c8cbcd7ff?pvs=4)
+                Reference: [참고 문서](https://github.com/f-lab-edu/Prostargram/wiki/%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EC%A0%84%EC%B2%B4-%EB%A1%9C%EC%A7%81)
                 """
     )
     @ApiResponses(value = {

--- a/src/main/java/flab/project/domain/user/controller/UsernameDuplicationController.java
+++ b/src/main/java/flab/project/domain/user/controller/UsernameDuplicationController.java
@@ -4,6 +4,7 @@ import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.config.exception.InvalidUserInputException;
 import flab.project.domain.user.exception.ExistedUsernameException;
+import flab.project.domain.user.model.UsernameTokenReturnDto;
 import flab.project.domain.user.service.UsernameDuplicationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -69,7 +70,7 @@ public class UsernameDuplicationController {
         summary = "닉네임 중복 검증 API",
         description = "닉네임 중복 여부를 검사한다.</br>"
             + "사용 가능한 닉네임이라는 응답을 받으면 15분간 다른 유저는 해당 닉네임으로 회원가입을 할 수 없다.</br>"
-            + "자세한 내용은 [해당 문서](https://www.notion.so/API-c3d78544b60249d39d524c01d0af2140?pvs=4)를 참고하길 바란다."
+            + "Reference: [참고 문서](https://github.com/f-lab-edu/Prostargram/wiki/%EB%8B%89%EB%84%A4%EC%9E%84-%EC%A4%91%EB%B3%B5-%ED%99%95%EC%9D%B8-API)"
     )
     @ApiResponses(value = {
         @ApiResponse(
@@ -139,14 +140,14 @@ public class UsernameDuplicationController {
         in = ParameterIn.QUERY,
         required = true
     )
-    @PostMapping(value = "/verify-username")
-    public SuccessResponse<String> verifyDuplicateUserName(
+    @PostMapping(value = "/verification/username")
+    public SuccessResponse<UsernameTokenReturnDto> verifyDuplicateUserName(
         @RequestParam("username")
         @NotBlank(message = "닉네임을 입력해주세요.")
         @Size(min = 1, max = 16, message = "닉네임의 최대 길이는 16자입니다.")
         String username
     ) {
-        String usernameToken = usernameDuplicationService.verifyDuplicateUserName(username);
+        UsernameTokenReturnDto usernameToken = usernameDuplicationService.verifyDuplicateUserName(username);
 
         return new SuccessResponse<>(usernameToken);
     }

--- a/src/main/java/flab/project/domain/user/controller/VerificationController.java
+++ b/src/main/java/flab/project/domain/user/controller/VerificationController.java
@@ -4,6 +4,7 @@ import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.user.exception.ExistedAccountException;
 import flab.project.domain.user.exception.InvalidVerificationCodeException;
+import flab.project.domain.user.model.EmailTokenReturnDto;
 import flab.project.domain.user.service.VerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,7 +28,7 @@ import org.springframework.validation.annotation.Validated;
 import java.util.stream.Collectors;
 
 @Tag(name = "회원가입 API", description = "회원가입 과정에서 사용되는 API</br>" +
-        "[회원가입 전체로직](https://www.notion.so/b577233726be48ab9706381c8cbcd7ff?pvs=4)은 링크를 참고하길 바란다.")
+        "[회원가입 전체로직](https://github.com/f-lab-edu/Prostargram/wiki/%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EC%A0%84%EC%B2%B4-%EB%A1%9C%EC%A7%81)은 링크를 참고하길 바란다.")
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -63,7 +64,7 @@ public class VerificationController {
 
     @Operation(summary = "인증코드 전송 API", description = "인증코드 전송 API이다.</br>" +
             "유저가 전달한 email로 이메일 인증코드가 전달되며 해당 인증코드는 **인증코드 검증 API**에서 사용된다.</br>" +
-            "[인증 코드 전송 API 개발 시 유의할점](https://www.notion.so/API-fb466d26300646d3934b9f948f2809ce?pvs=4)을 참고 바란다.")
+            "Reference: [참고 문서](https://github.com/f-lab-edu/Prostargram/wiki/%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9D-%EC%BD%94%EB%93%9C-%EC%A0%84%EC%86%A1-API)")
     @PostMapping(value = "/verification/email")
     @Parameter(
             name = "email",
@@ -130,7 +131,7 @@ public class VerificationController {
     @Operation(
             summary = "인증 코드 검증 API",
             description = "유저의 이메일에 발송된 인증 코드를 통해 유저의 이메일이 맞는지 확인하는 API이다.</br>" +
-                    "[해당 문서](https://www.notion.so/API-f70abf66b0714a739b8bbb5e822661c3?pvs=4)를 참고바란다."
+                    "Reference: [참고 문서](https://github.com/f-lab-edu/Prostargram/wiki/%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9D-%EC%BD%94%EB%93%9C-%EA%B2%80%EC%A6%9D-API)"
     )
     @Parameters(value = {
             @Parameter(
@@ -163,60 +164,51 @@ public class VerificationController {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "올바른 이메일 형식이여야 합니다.(이메일 형식과 일치하지 않거나 이메일이 전송되지 않은 경우)",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
+                            examples = {
+                                @ExampleObject(
+                                    name = "올바른 이메일 형식이여야 합니다.",
+                                    description = "올바른 이메일 형식이여야 합니다.(이메일 형식과 일치하지 않거나 이메일이 전송되지 않은 경우)",
                                     value = "{" +
-                                            "\"isSuccess\": false," +
-                                            "\"code\": 4000," +
-                                            "\"message\": \"올바른 이메일 형식이여야 합니다.\"" +
-                                            "}"
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "인증 코드를 입력해 주세요.",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
+                                        "\"isSuccess\": false," +
+                                        "\"code\": 4000," +
+                                        "\"message\": \"올바른 이메일 형식이여야 합니다.\"" +
+                                        "}"
+                                ),
+                                @ExampleObject(
+                                    name = "인증코드를 입력해 주세요.",
+                                    description = "인증 코드를 입력하지 않았거나, 공백 문자열(\"    \"), 빈 문자열(\"\")로 이루어진 경우",
                                     value = "{" +
-                                            "\"isSuccess\": false," +
-                                            "\"code\": 4000," +
-                                            "\"message\": \"인증코드를 입력해 주세요.\"" +
-                                            "}"
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "인증 코드가 일치하지 않습니다.",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
+                                        "\"isSuccess\": false," +
+                                        "\"code\": 4000," +
+                                        "\"message\": \"인증코드를 입력해 주세요.\"" +
+                                        "}"
+                                ),
+                                @ExampleObject(
+                                    name = "인증 코드가 일치하지 않습니다.",
+                                    description = "인증 코드가 일치하지 않는 경우",
                                     value = "{" +
-                                            "\"isSuccess\": false," +
-                                            "\"code\": 4000," +
-                                            "\"message\": \"인증 코드가 일치하지 않습니다.\"" +
-                                            "}"
-                            )
+                                        "\"isSuccess\": false," +
+                                        "\"code\": 4000," +
+                                        "\"message\": \"인증 코드가 일치하지 않습니다.\"" +
+                                        "}"
+                                )
+                            }
                     )
             ),
     })
-    @PostMapping(value = "/verification/email/{address}")
-    public SuccessResponse<Void> checkVerificationCode(
-            @PathVariable("address")
+    @PostMapping(value = "/verification/email/{email}")
+    public SuccessResponse<EmailTokenReturnDto> checkVerificationCode(
+            @PathVariable("email")
             @Email(message = "올바른 이메일 형식이여야 합니다.")
             @NotBlank(message = "올바른 이메일 형식이여야 합니다.") String email,
             @RequestParam("code")
             @NotBlank(message = "인증 코드를 입력해주세요") String code
     ) {
-        verificationService.checkVerificationCode(email, code);
+        EmailTokenReturnDto emailToken = verificationService.checkVerificationCode(email, code);
 
-        return new SuccessResponse<>();
+        return new SuccessResponse<>(emailToken);
     }
 }

--- a/src/main/java/flab/project/domain/user/model/EmailTokenReturnDto.java
+++ b/src/main/java/flab/project/domain/user/model/EmailTokenReturnDto.java
@@ -1,0 +1,15 @@
+package flab.project.domain.user.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class EmailTokenReturnDto {
+
+    private String emailToken;
+
+    public EmailTokenReturnDto(String emailToken) {
+        this.emailToken = emailToken;
+    }
+}

--- a/src/main/java/flab/project/domain/user/model/UsernameTokenReturnDto.java
+++ b/src/main/java/flab/project/domain/user/model/UsernameTokenReturnDto.java
@@ -1,0 +1,15 @@
+package flab.project.domain.user.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UsernameTokenReturnDto {
+
+    private String usernameToken;
+
+    public UsernameTokenReturnDto(String usernameToken) {
+        this.usernameToken = usernameToken;
+    }
+}

--- a/src/main/java/flab/project/domain/user/service/UsernameDuplicationService.java
+++ b/src/main/java/flab/project/domain/user/service/UsernameDuplicationService.java
@@ -3,6 +3,7 @@ package flab.project.domain.user.service;
 import flab.project.config.exception.InvalidUserInputException;
 import flab.project.domain.user.exception.ExistedUsernameException;
 import flab.project.domain.user.mapper.UserMapper;
+import flab.project.domain.user.model.UsernameTokenReturnDto;
 import flab.project.utils.RedisUtil;
 import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +24,13 @@ public class UsernameDuplicationService {
     private final RedisUtil redisUtil;
     private final UserMapper userMapper;
 
-    public String verifyDuplicateUserName(String username) {
+    public UsernameTokenReturnDto verifyDuplicateUserName(String username) {
         validateUsername(username);
 
         String verificationToken = createVerificationToken();
         reserveUsername(username, verificationToken);
 
-        return verificationToken;
+        return new UsernameTokenReturnDto(verificationToken);
     }
 
     private void validateUsername(String username) {

--- a/src/main/java/flab/project/domain/user/service/VerificationService.java
+++ b/src/main/java/flab/project/domain/user/service/VerificationService.java
@@ -4,6 +4,7 @@ import flab.project.config.exception.InvalidUserInputException;
 import flab.project.domain.user.exception.ExistedAccountException;
 import flab.project.domain.user.exception.InvalidVerificationCodeException;
 import flab.project.domain.user.mapper.UserMapper;
+import flab.project.domain.user.model.EmailTokenReturnDto;
 import flab.project.utils.RedisUtil;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
@@ -28,7 +29,8 @@ public class VerificationService {
     private static final String EMAIL_CONTENT_SUBTYPE = "html";
     private static final String CONTEXT_NAME = "verificationCode";
     private static final String TEMPLATE_NAME = "email";
-    private static final long MINUTES_FOR_DURATION = 60 * 5L;
+    private static final long FIVE_MINUTE = 60 * 5L;
+    private static final long FIFTEEN_MINUTE = 60 * 15L;
 
     // ^[A-Za-z0-9._%+-]+ : 사용자 명(ex. pask220), 영문 대/소문자, 숫자, ! 포함 가능
     // @[A-Za-z0-9.-] : @ 뒤의 도메인 이름, 영문 대/소문자, 숫자, 온점(.), 하이픈(-) 포함 가능
@@ -53,18 +55,23 @@ public class VerificationService {
         String verificationCode = createVerificationCode();
         MimeMessage message = composeEmail(email, EMAIL_SUBJECT, setContext(verificationCode));
 
-        redisUtil.setWithDuration(email, verificationCode, MINUTES_FOR_DURATION);
+        redisUtil.setWithDuration(email, verificationCode, FIVE_MINUTE);
 
         emailSender.send(message);
     }
 
-    public void checkVerificationCode(String email, String verificationCode) {
+    public EmailTokenReturnDto checkVerificationCode(String email, String verificationCode) {
         validateVerificationCodeFormat(verificationCode);
-        String validCode = redisUtil.get(email);
 
-        if (validCode == null || validCode.equals(verificationCode)) {
+        String validCode = redisUtil.get(email);
+        if (validCode == null || !validCode.equals(verificationCode)) {
             throw new InvalidVerificationCodeException();
         }
+
+        String emailToken = createVerificationCode();
+        redisUtil.setWithDuration(email, emailToken, FIFTEEN_MINUTE);
+
+        return new EmailTokenReturnDto(emailToken);
     }
 
     private void validateVerificationCodeFormat(String verificationCode) {


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #129  

## 📃 작업 사항
- swagger양식 통일
- 같은 api response code가 여러 개일 때, example에 대해서만 분리.
- notion에서 github wiki로 API 설명서 문서 이전
