### PR TITLE
[#149] 댓글 좋아요 추가 및 취소 Swagger 작성

### DIFF
--- a/src/main/java/flab/project/config/baseresponse/ResponseEnum.java
+++ b/src/main/java/flab/project/config/baseresponse/ResponseEnum.java
@@ -15,6 +15,7 @@ public enum ResponseEnum {
     DUPLICATE_USERNAME(false, 4005, "중복된 닉네임입니다."),
     UNAUTHORIZED_USER(false, 4006, "로그인이 필요합니다. 로그인 후 다시 시도하세요."),
     FORBIDDEN_ACCESS(false, 4007, "해당 요청에 대한 권한이 없습니다."),
+    NON_EXIST_COMMENT(false, 4008, "존재하지 않는 댓글입니다."),
 
     FAILED_TO_VERIFY_USER_IS_OWNER(false,403,"권한이 없습니다."),
     SERVER_ERROR(false, 5000, "서버 오류입니다. 잠시후 다시 시도하세요."),

--- a/src/main/java/flab/project/domain/like/controller/CommentLikeController.java
+++ b/src/main/java/flab/project/domain/like/controller/CommentLikeController.java
@@ -4,14 +4,23 @@ package flab.project.domain.like.controller;
 import flab.project.common.annotation.LoggedInUserId;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.like.service.CommentLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "댓글 좋아요 API")
 @RequiredArgsConstructor
 @RestController
 @Validated
@@ -19,6 +28,96 @@ public class CommentLikeController {
 
     private final CommentLikeService commentLikeService;
 
+    @Operation(
+            summary = "댓글 좋아요 추가 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 좋아요 추가 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+            responseCode = "401",
+            description = "로그인하지 않은 유저가 요청을 보낸 경우",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(
+                            value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 댓글에 좋아요를 요청한 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4008,
+                                                "message": "존재하지 않는 댓글에 대한 좋아요 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping("/comments/{commentId}/likes")
     public SuccessResponse<Void> addCommentLike(
             @PathVariable("commentId") @Positive long commentId,
@@ -29,6 +128,96 @@ public class CommentLikeController {
         return new SuccessResponse<>();
     }
 
+    @Operation(
+            summary = "댓글 좋아요 취소 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 좋아요 취소 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 댓글에 좋아요 취소를 요청한 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4001,
+                                                "message": "존재하지 않는 댓글에 대한 좋아요 취소 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @DeleteMapping("/comments/{commentId}/likes")
     public SuccessResponse<Void> cancelCommentLike(
             @PathVariable("commentId") @Positive long commentId,


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #149 

## 📃 작업 사항
1. 댓글 좋아요 추가에 대한 Swagger 작성
    - 200(성공) / 400(잘못된 요청) / 401(로그인 필요) / 404(존재하지 않는 댓글) / 500(서버 오류)
3. 댓글 좋아요 취소에 대한 Swagger 작성
    - 위와 동일
