### PR TITLE
[#163] 댓글 작성 및 조회 API Swagger 작성

### DIFF
--- a/src/main/java/flab/project/config/baseresponse/ResponseEnum.java
+++ b/src/main/java/flab/project/config/baseresponse/ResponseEnum.java
@@ -17,6 +17,7 @@ public enum ResponseEnum {
     FORBIDDEN_ACCESS(false, 4007, "해당 요청에 대한 권한이 없습니다."),
     NON_EXIST_COMMENT(false, 4008, "존재하지 않는 댓글입니다."),
 
+    // TODO FAILED_TO_VERIFY_USER_IS_OWNER는 추후 삭제 예정
     FAILED_TO_VERIFY_USER_IS_OWNER(false,403,"권한이 없습니다."),
     SERVER_ERROR(false, 5000, "서버 오류입니다. 잠시후 다시 시도하세요."),
     DUPLICATE_REQUEST(false, 5001, "서버 오류입니다. 잠시후 다시 시도하세요."),

--- a/src/main/java/flab/project/domain/comment/controller/CommentController.java
+++ b/src/main/java/flab/project/domain/comment/controller/CommentController.java
@@ -7,9 +7,6 @@ import flab.project.domain.comment.model.Comment;
 import flab.project.domain.comment.model.CommentWithUser;
 import flab.project.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -169,7 +166,7 @@ public class CommentController {
                                             {
                                                 "isSuccess": true,
                                                 "code": 4000,
-                                                "message": "올바르지 않은 요청입니다." 
+                                                "message": "올바르지 않은 요청입니다."
                                             }
                                             """
                             )

--- a/src/main/java/flab/project/domain/comment/controller/CommentController.java
+++ b/src/main/java/flab/project/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package flab.project.domain.comment.controller;
 
 import flab.project.common.annotation.LoggedInUserId;
+import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.comment.model.Comment;
 import flab.project.domain.comment.model.CommentWithUser;
@@ -9,16 +10,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "댓글 API")
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -26,10 +35,96 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation(summary = "댓글 작성 API")
-    @Parameters({@Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
-            @Parameter(name = "content", description = "게시물의 내용", in = ParameterIn.QUERY, required = true),
-            @Parameter(name = "parentId", description = "부모 댓글의 id", in = ParameterIn.QUERY)})
+    @Operation(
+            summary = "댓글 작성 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 작성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "로그인한 유저가 타인의 ID로 댓글 작성을 요청하는 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 4007,
+                                                "message": "해당 요청에 대한 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping(value = "/posts/{postId}/comments")
     public SuccessResponse<Comment> addComment(
             @PathVariable("postId") @Positive long postId,
@@ -42,12 +137,114 @@ public class CommentController {
         return new SuccessResponse<>(comment);
     }
 
+    @Operation(
+            summary = "댓글 조회 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다." 
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "로그인한 유저가 타인의 ID로 댓글 조회를 요청하는 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4007,
+                                                "message": "해당 요청에 대한 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시물의 댓글을 조회하는 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4002,
+                                                "message": "존재하지 않는 게시물입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     // Todo 토론 게시물의 경우, 진영을 의미하는 enum 추가 예정
-    @Operation(summary = "댓글 가져오기 API")
-    @Parameters({@Parameter(name = "postId", description = "게시물의 id", in = ParameterIn.PATH, required = true),
-            @Parameter(name = "userId", description = "유저의 id", in = ParameterIn.QUERY, required = true),
-            @Parameter(name = "lastCommentId", description = "가장 마지막으로 받아온 댓글의 id", in = ParameterIn.QUERY, required = false),
-            @Parameter(name = "limit", description = "한 번에 조회할 댓글의 개수", in = ParameterIn.QUERY, required = true)})
     @GetMapping(value = "/posts/{postId}/comments")
     public SuccessResponse<List<CommentWithUser>> getComments(
             @PathVariable("postId") @Positive long postId,

--- a/src/main/java/flab/project/domain/comment/controller/CommentController.java
+++ b/src/main/java/flab/project/domain/comment/controller/CommentController.java
@@ -100,7 +100,7 @@ public class CommentController {
                                             value = """
                                             {
                                                 "isSucces": false,
-                                                "code": 4001,
+                                                "code": 4002,
                                                 "message": "존재하지 않는 게시물입니다."
                                             }
                                             """

--- a/src/main/java/flab/project/domain/comment/controller/CommentController.java
+++ b/src/main/java/flab/project/domain/comment/controller/CommentController.java
@@ -89,13 +89,14 @@ public class CommentController {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 게시물에 댓글을 작성할 때",
+                    description = "존재하지 않는 게시물에 댓글을 작성 또는 존재하지 않는 댓글에 대댓글을 작성할 경우",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = FailResponse.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "존재하지 않는 게시물입니다.",
+                                            name = "존재하지 않는 게시물에 댓글을 작성할 경우",
+                                            description = "존재하지 않는 게시물입니다.",
                                             value = """
                                             {
                                                 "isSucces": false,
@@ -105,7 +106,8 @@ public class CommentController {
                                             """
                                     ),
                                     @ExampleObject(
-                                            name = "존재하지 않는 댓글입니다.",
+                                            name = "존재하지 않는 댓글에 대댓글을 작성할 경우",
+                                            description = "존재하지 않는 댓글입니다.",
                                             value = """
                                             {
                                                 "isSucces": false,
@@ -204,19 +206,34 @@ public class CommentController {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 게시물의 댓글을 조회하는 경우",
+                    description = "존재하지 않는 게시물의 댓글을 조회 또는 존재하지 않는 댓글의 대댓글을 조회할 경우",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 게시물의 댓글을 조회할 경우",
+                                            description = "존재하지 않는 게시물입니다.",
+                                            value = """
                                             {
                                                 "isSuccess": false,
                                                 "code": 4002,
                                                 "message": "존재하지 않는 게시물입니다."
                                             }
                                             """
-                            )
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 댓글의 대댓글을 조회할 경우",
+                                            description = "존재하지 않는 댓글입니다.",
+                                            value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4008,
+                                                "message": "존재하지 않는 댓글입니다."
+                                            }
+                                            """
+                                    )
+                            }
                     )
             ),
             @ApiResponse(

--- a/src/main/java/flab/project/domain/comment/controller/CommentController.java
+++ b/src/main/java/flab/project/domain/comment/controller/CommentController.java
@@ -88,20 +88,33 @@ public class CommentController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "403",
-                    description = "로그인한 유저가 타인의 ID로 댓글 작성을 요청하는 경우",
+                    responseCode = "404",
+                    description = "존재하지 않는 게시물에 댓글을 작성할 때",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 게시물입니다.",
+                                            value = """
                                             {
                                                 "isSucces": false,
-                                                "code": 4007,
-                                                "message": "해당 요청에 대한 권한이 없습니다."
+                                                "code": 4001,
+                                                "message": "존재하지 않는 게시물입니다."
                                             }
                                             """
-                            )
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 댓글입니다.",
+                                            value = """
+                                            {
+                                                "isSucces": false,
+                                                "code": 4008,
+                                                "message": "존재하지 않는 댓글입니다."
+                                            }
+                                            """
+                                    )
+                            }
                     )
             ),
             @ApiResponse(
@@ -184,23 +197,6 @@ public class CommentController {
                                                 "isSuccess": false,
                                                 "code": 4006,
                                                 "message": "로그인이 필요합니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "로그인한 유저가 타인의 ID로 댓글 조회를 요청하는 경우",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "isSuccess": false,
-                                                "code": 4007,
-                                                "message": "해당 요청에 대한 권한이 없습니다."
                                             }
                                             """
                             )

--- a/src/main/java/flab/project/domain/like/controller/CommentLikeController.java
+++ b/src/main/java/flab/project/domain/like/controller/CommentLikeController.java
@@ -2,6 +2,7 @@ package flab.project.domain.like.controller;
 
 
 import flab.project.common.annotation.LoggedInUserId;
+import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.like.service.CommentLikeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,7 +55,7 @@ public class CommentLikeController {
                     description = "잘못된 요청",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -71,7 +72,7 @@ public class CommentLikeController {
             description = "로그인하지 않은 유저가 요청을 보낸 경우",
             content = @Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = SuccessResponse.class),
+                    schema = @Schema(implementation = FailResponse.class),
                     examples = @ExampleObject(
                             value = """
                                             {
@@ -84,11 +85,28 @@ public class CommentLikeController {
                     )
             ),
             @ApiResponse(
+                    responseCode = "403",
+                    description = "로그인한 유저가 타인의 ID로 댓글 좋아요를 요청하는 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4007,
+                                                "message": "해당 요청에 대한 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않는 댓글에 좋아요를 요청한 경우",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -105,7 +123,7 @@ public class CommentLikeController {
                     description = "서버 오류",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -154,7 +172,7 @@ public class CommentLikeController {
                     description = "잘못된 요청",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -171,7 +189,7 @@ public class CommentLikeController {
                     description = "로그인하지 않은 유저가 요청을 보낸 경우",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -184,11 +202,28 @@ public class CommentLikeController {
                     )
             ),
             @ApiResponse(
+                    responseCode = "403",
+                    description = "로그인한 유저가 타인의 ID로 댓글 좋아요 삭제를 요청하는 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4007,
+                                                "message": "해당 요청에 대한 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않는 댓글에 좋아요 취소를 요청한 경우",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
@@ -205,7 +240,7 @@ public class CommentLikeController {
                     description = "서버 오류",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SuccessResponse.class),
+                            schema = @Schema(implementation = FailResponse.class),
                             examples = @ExampleObject(
                                     value = """
                                             {

--- a/src/main/java/flab/project/domain/user/controller/FollowController.java
+++ b/src/main/java/flab/project/domain/user/controller/FollowController.java
@@ -7,8 +7,6 @@ import flab.project.domain.user.model.User;
 import flab.project.domain.user.enums.GetFollowsType;
 import flab.project.domain.user.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/flab/project/domain/user/controller/FollowController.java
+++ b/src/main/java/flab/project/domain/user/controller/FollowController.java
@@ -276,7 +276,7 @@ public class FollowController {
                                             {
                                                 "isSuccess": false,
                                                 "code": 4006,
-                                                "message": ""
+                                                "message": "로그인이 필요합니다."
                                             }
                                             """
                             )


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #163 

## 📃 작업 사항
1. 댓글 작성 API Swagger 작성
- 200(성공), 400(잘못된 요청), 401(로그인 필요), ~403(권한 없음)~, 404(존재하지 않는 postId 또는 parentId), 500(서버 오류)
  - 이때, 404에 대해 `postId`와 `parentId` 케이스를 나눠서 작성
2. 댓글 조회 API Swagger 작성
- 200(성공), 400(잘못된 요청), 401(로그인 필요), ~403(권한 없음)~, 404(존재하지 않는 postId), 500(서버 오류)
