### PR TITLE
[#168] FollowController userId 검증 로직 추가 및 로직 수정

### DIFF
--- a/src/main/java/flab/project/domain/user/model/User.java
+++ b/src/main/java/flab/project/domain/user/model/User.java
@@ -10,6 +10,13 @@ public class User extends BasicUser {
     @Schema(example = "카카오")
     private String departmentName;
 
+    public User(long userId, String userName, String profileImgUrl, String departmentName) {
+        super(userId, userName, profileImgUrl);
+        this.departmentName = departmentName;
+    }
+    public User() {
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/flab/project/domain/user/service/FollowService.java
+++ b/src/main/java/flab/project/domain/user/service/FollowService.java
@@ -20,28 +20,22 @@ public class FollowService {
 
     private final FollowMapper followMapper;
 
-    public SuccessResponse<List<User>> getFollows(Long userId, GetFollowsType requestType) {
+    public List<User> getFollows(Long userId, GetFollowsType requestType) {
         validateUserIdPositive(userId);
 
-        List<User> result = followMapper.findAll(userId, requestType);
-
-        return new SuccessResponse<>(result);
+        return followMapper.findAll(userId, requestType);
     }
 
-    public SuccessResponse addFollow(Follows follows) {
+    public int addFollow(Follows follows) {
         validateFromUserIdAndToUserIdSame(follows);
 
-        followMapper.addFollow(follows);
-
-        return new SuccessResponse();
+        return followMapper.addFollow(follows);
     }
 
-    public SuccessResponse deleteFollow(Follows follows) {
+    public void deleteFollow(Follows follows) {
         validateFromUserIdAndToUserIdSame(follows);
 
         followMapper.deleteFollow(follows);
-
-        return new SuccessResponse<>();
     }
 
     private void validateUserIdPositive(Long userId) {

--- a/src/main/java/flab/project/domain/user/service/FollowService.java
+++ b/src/main/java/flab/project/domain/user/service/FollowService.java
@@ -1,6 +1,5 @@
 package flab.project.domain.user.service;
 
-import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.config.exception.InvalidUserInputException;
 import flab.project.domain.user.model.Follows;
 import flab.project.domain.user.model.User;
@@ -9,7 +8,6 @@ import flab.project.domain.user.mapper.FollowMapper;
 
 import java.util.List;
 
-import flab.project.utils.FollowerRedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,10 +24,10 @@ public class FollowService {
         return followMapper.findAll(userId, requestType);
     }
 
-    public int addFollow(Follows follows) {
+    public void addFollow(Follows follows) {
         validateFromUserIdAndToUserIdSame(follows);
 
-        return followMapper.addFollow(follows);
+        followMapper.addFollow(follows);
     }
 
     public void deleteFollow(Follows follows) {

--- a/src/test/java/flab/project/controller/FollowControllerUnitTest.java
+++ b/src/test/java/flab/project/controller/FollowControllerUnitTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import flab.project.config.baseresponse.ResponseEnum;
-import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.user.model.Follows;
 import flab.project.domain.user.controller.FollowController;
 import flab.project.domain.user.model.User;

--- a/src/test/java/flab/project/controller/FollowControllerUnitTest.java
+++ b/src/test/java/flab/project/controller/FollowControllerUnitTest.java
@@ -14,6 +14,7 @@ import flab.project.config.baseresponse.ResponseEnum;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.user.model.Follows;
 import flab.project.domain.user.controller.FollowController;
+import flab.project.domain.user.model.User;
 import flab.project.domain.user.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 @WebMvcTest(controllers = FollowController.class)
 class FollowControllerUnitTest {
@@ -40,13 +43,15 @@ class FollowControllerUnitTest {
     private static final String ADD_FOLLOWS_REQUEST_URL = "/users/{userId}/follows";
     private static final String DELETE_FOLLOWS_REQUEST_URL = "/users/{userId}/follows";
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워를 가져올 수 있다.")
     @Test
     void getFollowers() throws Exception {
-        long userId = 1;
-        given(followService.getFollows(userId, FOLLOWERS))
-                .willReturn(new SuccessResponse<>());
+        List<User> followerList = List.of(
+                new User(1L, "이은비", "https://example.com", "네이버"));
+
+        given(followService.getFollows(1L, FOLLOWERS))
+                .willReturn(followerList);
 
         mockMvc.perform(
                         get(GET_FOLLOWERS_REQUEST_URL, 1)
@@ -58,7 +63,7 @@ class FollowControllerUnitTest {
                 .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워를 가져올 때, userId는 양수여야 한다.")
     @Test
     void getFollowersWithNonPositiveId() throws Exception {
@@ -81,7 +86,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워를 가져올 때, userId는 정수가 보내줘야 하며 타입 변환이 불가능할 경우 INVALID_USER_INPUT을 반환한다.")
     @Test
     void getFollowersWithNotLongId() throws Exception {
@@ -95,13 +100,15 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로잉을 가져올 수 있다.")
     @Test
     void getFollowings() throws Exception {
-        long userId = 1;
-        given(followService.getFollows(userId, FOLLOWINGS))
-                .willReturn(new SuccessResponse<>());
+        List<User> followingList = List.of(
+                new User(1L, "이은비", "https://example.com", "네이버"));
+
+        given(followService.getFollows(1L, FOLLOWINGS))
+                .willReturn(followingList);
 
         mockMvc.perform(
                         get(GET_FOLLOWINGS_REQUEST_URL, 1)
@@ -114,7 +121,7 @@ class FollowControllerUnitTest {
 
     }
 
-    @WithMockUser
+    @WithMockUser(username = "-1")
     @DisplayName("팔로잉을 가져올 때, userId는 양수여야 한다.")
     @Test
     void getFollowingsWithNonPositiveId() throws Exception {
@@ -137,7 +144,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로잉을 가져올 때, userId는 정수가 보내줘야 하며 타입 변환이 불가능할 경우 INVALID_USER_INPUT을 반환한다.")
     @Test
     void getFollowingsWithNotLongId() throws Exception {
@@ -151,13 +158,15 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉을 한번에 가져올 수 있다.")
     @Test
     void getFollowersAndFollowings() throws Exception {
-        long userId = 1;
-        given(followService.getFollows(userId, ALL))
-                .willReturn(new SuccessResponse<>());
+        List<User> allList = List.of(
+                new User(1L, "이은비", "https://example.com", "네이버" ));
+
+        given(followService.getFollows(1L, ALL))
+                .willReturn(allList);
 
         mockMvc.perform(
                         get(GET_FOLLOWERS_AND_FOLLOWINGS_REQUEST_URL, 1)
@@ -169,7 +178,7 @@ class FollowControllerUnitTest {
                 .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "-1")
     @DisplayName("팔로워/팔로잉 모두를 가져올 때, userId는 양수여야한다.")
     @Test
     void getAllFollowsWithNonPositiveId() throws Exception {
@@ -192,7 +201,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉 모두를 가져올 때, userId는 정수가 보내줘야 하며 타입 변환이 불가능할 경우 INVALID_USER_INPUT을 반환한다.")
     @Test
     void getAllFollowsWithNotLongId() throws Exception {
@@ -206,7 +215,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉을 생성할 때, fromUserId와 toUserId에는 양수만 올 수 있다.")
     @Test
     void parameterOfAddFollowRequestDtoIsPositive() throws Exception {
@@ -274,7 +283,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉을 생성할 때, fromUserId와 toUserId는 필수 값이다.")
     @Test
     void AllParameterOfAddFollowRequestDtoIsRequired() throws Exception {
@@ -301,7 +310,7 @@ class FollowControllerUnitTest {
             .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉을 삭제할 때, fromUserId와 toUserId에는 양수만 올 수 있다.")
     @Test
     void parameterOfDeleteFollowRequestDtoIsPositive() throws Exception {
@@ -369,7 +378,7 @@ class FollowControllerUnitTest {
                 .andExpect(jsonPath("$.message").value(ResponseEnum.INVALID_USER_INPUT.getMessage()));
     }
 
-    @WithMockUser
+    @WithMockUser(username = "1")
     @DisplayName("팔로워/팔로잉을 삭제할 때, fromUserId와 toUserId는 필수 값이다.")
     @Test
     void AllParameterOfDeleteFollowRequestDtoIsRequired() throws Exception {


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #168 

## 📃 작업 사항
- FollowController에 jwt의 userId와 pathVariable의 userId를 비교하는 assertUserIdOwner() 검증 로직 추가
- 응답을 Controller가 반환하도록 수정
- FollowController를 추가 및 수정하면서 깨진 FollowControllerUnitTest 수정
- FollowController를 수정하면서 사용되지 않는 import문 삭제
