### PR TITLE
[#189] 게시물 상세 보기 API Swagger 작성 및 로직 수정

### DIFF
--- a/src/main/java/flab/project/config/exception/NotFoundException.java
+++ b/src/main/java/flab/project/config/exception/NotFoundException.java
@@ -2,9 +2,6 @@ package flab.project.config.exception;
 
 public class NotFoundException extends RuntimeException {
 
-    public NotFoundException() {
-    }
-
     public NotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/flab/project/domain/post/controller/PostController.java
+++ b/src/main/java/flab/project/domain/post/controller/PostController.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -122,8 +121,7 @@ public class PostController {
             )
     })
     @GetMapping("/posts/{postId}/basic-post")
-    public SuccessResponse<PostWithUser> getBasicPostDetail(@PathVariable("postId") @Positive long postId)
-            throws NotFoundException {
+    public SuccessResponse<PostWithUser> getBasicPostDetail(@PathVariable("postId") @Positive long postId) {
         long userId = 1L;
 
         return postService.getPostDetail(postId, userId, PostType.BASIC);
@@ -221,8 +219,7 @@ public class PostController {
             )
     })
     @GetMapping("/posts/{postId}/debate-post")
-    public SuccessResponse<PostWithUser> getDebatePostDetail(@PathVariable("postId") @Positive long postId)
-            throws NotFoundException {
+    public SuccessResponse<PostWithUser> getDebatePostDetail(@PathVariable("postId") @Positive long postId) {
         long userId = 1L;
 
         return postService.getPostDetail(postId, userId, PostType.DEBATE);
@@ -320,8 +317,7 @@ public class PostController {
             )
     })
     @GetMapping("/posts/{postId}/poll-post")
-    public SuccessResponse<PostWithUser> getPollPostDetail(@PathVariable("postId") @Positive long postId)
-            throws NotFoundException {
+    public SuccessResponse<PostWithUser> getPollPostDetail(@PathVariable("postId") @Positive long postId) {
         long userId = 1L;
 
         return postService.getPostDetail(postId, userId, PostType.POLL);

--- a/src/main/java/flab/project/domain/post/controller/PostController.java
+++ b/src/main/java/flab/project/domain/post/controller/PostController.java
@@ -1,17 +1,28 @@
 package flab.project.domain.post.controller;
 
+import flab.project.config.baseresponse.FailResponse;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.post.model.PostWithUser;
 import flab.project.domain.post.enums.PostType;
 import flab.project.domain.post.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.javassist.NotFoundException;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "게시물 API")
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -19,6 +30,97 @@ public class PostController {
 
     private final PostService postService;
 
+    @Operation(
+            summary = "일반 게시물 상세 보기 API",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일반 게시물 상세 보기 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                            value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 일반 게시물을 상세 보기 할 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4002,
+                                                "message": "존재하지 않는 일반 게시물입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/posts/{postId}/basic-post")
     public SuccessResponse<PostWithUser> getBasicPostDetail(@PathVariable("postId") @Positive long postId)
             throws NotFoundException {
@@ -27,6 +129,97 @@ public class PostController {
         return postService.getPostDetail(postId, userId, PostType.BASIC);
     }
 
+    @Operation(
+            summary = "토론 게시물 상세 보기 API",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "토론 게시물 상세 보기 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 토론 게시물을 상세 보기 할 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4002,
+                                                "message": "존재하지 않는 토론 게시물입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/posts/{postId}/debate-post")
     public SuccessResponse<PostWithUser> getDebatePostDetail(@PathVariable("postId") @Positive long postId)
             throws NotFoundException {
@@ -35,6 +228,97 @@ public class PostController {
         return postService.getPostDetail(postId, userId, PostType.DEBATE);
     }
 
+    @Operation(
+            summary = "통계 게시물 상세 보기 API",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "통계 게시물 상세 보기 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "code": 1000,
+                                                "message": "요청에 성공하였습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4000,
+                                                "message": "올바르지 않은 요청입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 유저가 요청을 보낸 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4006,
+                                                "message": "로그인이 필요합니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 통계 게시물을 상세 보기 할 경우",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 4002,
+                                                "message": "존재하지 않는 통계 게시물입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "code": 5000,
+                                                "message": "서버 오류입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/posts/{postId}/poll-post")
     public SuccessResponse<PostWithUser> getPollPostDetail(@PathVariable("postId") @Positive long postId)
             throws NotFoundException {

--- a/src/main/java/flab/project/domain/post/service/PostService.java
+++ b/src/main/java/flab/project/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package flab.project.domain.post.service;
 
 import flab.project.config.exception.InvalidUserInputException;
+import flab.project.config.exception.NotFoundException;
 import flab.project.domain.post.model.AddPostRequest;
 import flab.project.domain.post.model.*;
 import flab.project.domain.post.mapper.PostMapper;
@@ -16,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.post.enums.PostType;
 import flab.project.domain.user.mapper.UserMapper;
-import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -33,15 +33,14 @@ public class PostService {
         postMapper.save(userId, post);
     }
 
-    public SuccessResponse<PostWithUser> getPostDetail(long postId, long userId, PostType postType)
-        throws NotFoundException {
+    public SuccessResponse<PostWithUser> getPostDetail(long postId, long userId, PostType postType) {
         validateGetPostDetail(postId, userId);
 
         BasicUser basicUser = userMapper.getBasicUser(userId);
         BasePost post = getPostDetailUsingPostType(postId, userId, postType);
 
         if (post == null) {
-            throw new NotFoundException("post not found");
+            throw new NotFoundException("post not found.");
         }
 
         PostWithUser postWithUser = new PostWithUser(post, basicUser);

--- a/src/main/java/flab/project/domain/post/service/VoteService.java
+++ b/src/main/java/flab/project/domain/post/service/VoteService.java
@@ -88,8 +88,11 @@ public class VoteService {
     }
 
     private boolean getAllowMultipleVotes(long postId, PostType postType) {
-        return postType == PostType.POLL ? pollMetadataMapper.findAllowMultipleVotes(postId)
-                : false;
+        if(postType != PostType.POLL){
+            return false;
+        }
+
+        return pollMetadataMapper.findAllowMultipleVotes(postId);
     }
 
     private void validatePollPostPeriod(long postId) {

--- a/src/main/java/flab/project/domain/post/service/VoteService.java
+++ b/src/main/java/flab/project/domain/post/service/VoteService.java
@@ -31,7 +31,7 @@ public class VoteService {
             PostType postType
     ) {
         if (postType == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("post not found.");
         }
 
         validateVote(postId, optionIds, userId, postType);


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #189 

## 📃 작업 사항
- `200(성공)`, `400(잘못된 요청)`, `401(로그인 필요)`, `404(게시물 찾을 수 없음)`, `500(서버 오류)` 케이스에 대해 Swagger 작성
- 커스텀 NotFoundException으로 로직 수정
