### PR TITLE
[#217] FollowController 리팩토링

### DIFF
--- a/src/main/java/flab/project/domain/user/controller/FollowController.java
+++ b/src/main/java/flab/project/domain/user/controller/FollowController.java
@@ -103,23 +103,6 @@ public class FollowController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 유저의 팔로워 목록을 조회하는 경우",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "isSuccess": false,
-                                                "code": 4001,
-                                                "message": "존재하지 않는 유저에 대한 요청입니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "500",
                     description = "서버 오류",
                     content = @Content(
@@ -217,23 +200,6 @@ public class FollowController {
                                                 "isSuccess": false,
                                                 "code": 4006,
                                                 "message": "로그인이 필요합니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 유저의 팔로잉 목록을 조회하는 경우",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "isSuccess": false,
-                                                "code": 4001,
-                                                "message": "존재하지 않는 유저에 대한 요청입니다."
                                             }
                                             """
                             )
@@ -465,23 +431,6 @@ public class FollowController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 유저가 팔로워/팔로잉 추가를 요청받는 경우",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "isSuccess": false,
-                                                "code": 4001,
-                                                "message": "존재하지 않는 유저에 대한 요청입니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "500",
                     description = "서버 오류",
                     content = @Content(
@@ -580,23 +529,6 @@ public class FollowController {
                                                 "isSuccess": false,
                                                 "code": 4007,
                                                 "message": "해당 요청에 대한 권한이 없습니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 유저가 팔로워/팔로잉 삭제를 요청받는 경우",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = FailResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "isSuccess": false,
-                                                "code": 4001,
-                                                "message": "존재하지 않는 유저에 대한 요청입니다."
                                             }
                                             """
                             )

--- a/src/main/resources/mapper/flab/project/mapper/follow-mapper.xml
+++ b/src/main/resources/mapper/flab/project/mapper/follow-mapper.xml
@@ -45,12 +45,6 @@
         </choose>
     </select>
 
-    <select id="findAllFollowerIds" resultType="Long">
-        SELECT from_user_id
-        FROM FOLLOWS
-        WHERE to_user_id = #{userId};
-    </select>
-
     <insert id="addFollow" parameterType="Follows">
         INSERT INTO FOLLOWS(from_user_id, to_user_id)
         VALUES (#{followRequestDto.fromUserId}, #{followRequestDto.toUserId});


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #217 

## 📃 작업 사항
- 1. FollowController에서 404 케이스를 모두 삭제합니다.
  - (1) FollowController의 메서드는 기본적으로 @LoggedInUserId의 userId를 기준으로 진행이 됩니다.
  - (2) 따라서, 팔로워 조회 / 팔로잉 조회 / 팔로워 또는 팔로잉 조회 모두 "현재 로그인 중인 유저의 userId"를 기반으로 조회해옵니다.
  - (3) 이때, 404 케이스 - 즉, 현재 유저가 존재하지 않는 유저라는 말은 성립할 수 없습니다.
  - (4) 결과적으로, 위 케이스는 정상적이지 않는 유저를 대상으로 한 case이기 때문에, 조회 / 생성 / 삭제의 경우 빈 배열 반환 / FK 제약 조건(= 없는 유저에 대해 추가하려고 하므로 발생) / 성공과 같은 결과가 노출되어야 합니다.
  - (5) 그렇기에 404 케이스를 모두 삭제 완료하였습니다.
- 2. follow-mapper에서 사용되지 않는 쿼리를 삭제합니다.
