### PR TITLE
[Feat] Security 허용 URI 수정

### DIFF
--- a/src/main/java/flab/project/config/SecurityConfig.java
+++ b/src/main/java/flab/project/config/SecurityConfig.java
@@ -52,11 +52,15 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             .authorizeHttpRequests(authorize ->
-                authorize.requestMatchers("/login", "/users",
-                                "/send", "/verification/email/**", "/verification/username",
-                                "/swagger-ui/**", "/v3/api-docs/**",
-                                "/actuator/**",
-                                "/posts/**"
+                authorize.requestMatchers(
+                        "/login",
+                                "/users",
+                                "/send",
+                                "/verification/email/**",
+                                "/verification/username",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/actuator/**"
                         ).permitAll()
                     .anyRequest().authenticated()
             )


### PR DESCRIPTION
## 📃 작업 사항
- SpringSecurity 허용 URI에 /posts 도메인이 허용되어 있었으나 해당 도메인 비허용으로 수정
