### PR TITLE
[Fix] 아이디/패스워드가 틀렸을 때 응답 포맷 변경

### DIFF
--- a/src/main/java/flab/project/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/project/domain/user/service/CustomUserDetailsService.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,7 +19,6 @@ import java.util.List;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final AuthenticationMapper authenticationMapper;
-    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/java/flab/project/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/project/domain/user/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package flab.project.domain.user.service;
 import flab.project.domain.user.model.UserForAuth;
 import flab.project.domain.user.mapper.AuthenticationMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -25,10 +26,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         UserForAuth user = authenticationMapper.getUser(username);
 
-        // todo EncodedPassword가 어떻게 나올 수 있지..?
-        String encodedPassword = passwordEncoder.encode(user.getPassword());
+        if (user == null) {
+            throw new BadCredentialsException("아이디 혹은 패스워드가 틀렸습니다.");
+        }
 
-        // todo 왜 권한정보를 List로 받아야 하게 만들었을까..? 권한을 계층 구조로 만들어야하나..?
         List<GrantedAuthority> grantedAuthorities = List.of(new SimpleGrantedAuthority(user.getUserType().name()));
 
         return new User(String.valueOf(user.getUserId()), user.getPassword(), grantedAuthorities);


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #249  

## 📃 작업 사항
- 현재 API 에서 패스워드가 틀렸을 때는 정상적인 응답이 반환되지만, 아이디가 틀렸을 때는 "서버 에러입니다"반환
- 패스워드가 틀렸을 때와 같이 "아이디 혹은 패스워드가 틀렸습니다"응답 반환 하도록 수정
- 이는 보안적인 이유로 아이디/패스워드 중 무엇이 틀렸는 지를 숨기기 위함.
