### PR TITLE
[#255] 이미지 업로드 로직 수정

### DIFF
--- a/src/main/java/flab/project/common/file_storage/FileUploader.java
+++ b/src/main/java/flab/project/common/file_storage/FileUploader.java
@@ -23,14 +23,6 @@ public class FileUploader {
     public static final int EXPIRATION_TIME = 1000 * 60 * 15;
     private final AmazonS3 amazonS3;
 
-    public UploadedFileUrls generatePreSignedUrls(long userId, int imageCount, FileType type) {
-        Set<UploadedFileUrl> uploadedFileUrls = IntStream.range(0, imageCount)
-                .mapToObj(i -> generatePreSignedUrl(userId, type))
-                .collect(Collectors.toSet());
-
-        return new UploadedFileUrls(uploadedFileUrls);
-    }
-
     public UploadedFileUrls generatePreSignedUrls(long userId, ImageUploadRequest imageUploadRequest) {
         Set<UploadedFileUrl> uploadedFileUrls = IntStream.range(0, imageUploadRequest.getImageCount())
                 .mapToObj(i -> generatePreSignedUrl(userId, imageUploadRequest.getFileType()))

--- a/src/main/java/flab/project/common/file_storage/FileUploader.java
+++ b/src/main/java/flab/project/common/file_storage/FileUploader.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.*;
 import flab.project.domain.file.enums.FileType;
+import flab.project.domain.file.model.ImageUploadRequest;
 import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
@@ -22,9 +23,17 @@ public class FileUploader {
     public static final int EXPIRATION_TIME = 1000 * 60 * 15;
     private final AmazonS3 amazonS3;
 
-    public UploadedFileUrls generatePreSignedUrls(long userId, int fileCount, FileType fileType) {
-        Set<UploadedFileUrl> uploadedFileUrls = IntStream.range(0, fileCount)
-                .mapToObj(i -> generatePreSignedUrl(userId, fileType))
+    public UploadedFileUrls generatePreSignedUrls(long userId, int imageCount, FileType type) {
+        Set<UploadedFileUrl> uploadedFileUrls = IntStream.range(0, imageCount)
+                .mapToObj(i -> generatePreSignedUrl(userId, type))
+                .collect(Collectors.toSet());
+
+        return new UploadedFileUrls(uploadedFileUrls);
+    }
+
+    public UploadedFileUrls generatePreSignedUrls(long userId, ImageUploadRequest imageUploadRequest) {
+        Set<UploadedFileUrl> uploadedFileUrls = IntStream.range(0, imageUploadRequest.getImageCount())
+                .mapToObj(i -> generatePreSignedUrl(userId, imageUploadRequest.getFileType()))
                 .collect(Collectors.toSet());
 
         return new UploadedFileUrls(uploadedFileUrls);

--- a/src/main/java/flab/project/domain/file/ImageController.java
+++ b/src/main/java/flab/project/domain/file/ImageController.java
@@ -1,0 +1,28 @@
+package flab.project.domain.file;
+
+import flab.project.common.annotation.LoggedInUserId;
+import flab.project.common.file_storage.FileUploader;
+import flab.project.common.file_storage.UploadedFileUrls;
+import flab.project.config.baseresponse.SuccessResponse;
+import flab.project.domain.file.model.ImageUploadRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final FileUploader fileUploader;
+
+    @PostMapping("/images")
+    public SuccessResponse<UploadedFileUrls> requestPresignedUrls(
+            @LoggedInUserId Long userId,
+            @RequestBody ImageUploadRequest imageUploadRequest
+    ) {
+        UploadedFileUrls uploadedFileUrls = fileUploader.generatePreSignedUrls(userId, imageUploadRequest);
+
+        return new SuccessResponse<>(uploadedFileUrls);
+    }
+}

--- a/src/main/java/flab/project/domain/file/model/ImageUploadRequest.java
+++ b/src/main/java/flab/project/domain/file/model/ImageUploadRequest.java
@@ -1,0 +1,13 @@
+package flab.project.domain.file.model;
+
+import flab.project.domain.file.enums.FileType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ImageUploadRequest {
+
+    private int imageCount;
+    private FileType fileType;
+}

--- a/src/main/java/flab/project/domain/post/facade/BasicPostFacade.java
+++ b/src/main/java/flab/project/domain/post/facade/BasicPostFacade.java
@@ -1,12 +1,9 @@
 package flab.project.domain.post.facade;
 
-import flab.project.common.file_storage.FileUploader;
-import flab.project.common.file_storage.UploadedFileUrls;
 import flab.project.domain.post.model.AddBasicPostRequest;
 import flab.project.domain.post.model.AddPostRequest;
 import flab.project.domain.post.model.BasePost;
 import flab.project.domain.post.model.BasicPost;
-import flab.project.domain.file.enums.FileType;
 import flab.project.domain.feed.service.FanOutService;
 import flab.project.domain.post.service.PostHashTagService;
 import flab.project.domain.post.service.PostImageService;
@@ -18,18 +15,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class BasicPostFacade extends PostFacadeTemplate {
 
-    private final FileUploader fileUploader;
     private final PostImageService postImageService;
 
     public BasicPostFacade(
         PostService postService,
         PostHashTagService postHashTagService,
         FanOutService fanOutService,
-        FileUploader fileUploader,
         PostImageService postImageService
     ) {
         super(postService, postHashTagService, fanOutService);
-        this.fileUploader = fileUploader;
         this.postImageService = postImageService;
     }
 
@@ -44,11 +38,9 @@ public class BasicPostFacade extends PostFacadeTemplate {
     protected BasePost handlePostMetadata(long userId, AddPostRequest post) {
         AddBasicPostRequest addBasicPostRequest = (AddBasicPostRequest) post;
 
-        UploadedFileUrls uploadedFileUrls
-            = fileUploader.generatePreSignedUrls(userId, addBasicPostRequest.getImageCount(), FileType.POST_IMAGE);
-        postImageService.saveAll(addBasicPostRequest.getPostId(), uploadedFileUrls.getContentUrls());
+        postImageService.saveAll(addBasicPostRequest.getPostId(), addBasicPostRequest.getContentUrls());
 
-        return new BasicPost(addBasicPostRequest, userId, uploadedFileUrls);
+        return new BasicPost(addBasicPostRequest, userId);
     }
 
     @Override

--- a/src/main/java/flab/project/domain/post/model/AddBasicPostRequest.java
+++ b/src/main/java/flab/project/domain/post/model/AddBasicPostRequest.java
@@ -5,10 +5,10 @@ import static flab.project.domain.post.enums.PostType.BASIC;
 import flab.project.domain.post.enums.PostType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.validator.constraints.Range;
 
 @SuperBuilder
 @NoArgsConstructor
@@ -17,8 +17,7 @@ public class AddBasicPostRequest extends AddPostRequest {
 
     private static final PostType postType = BASIC;
 
-    @Range(min = 1, max = 6)
-    private int imageCount;
+    private Set<String> contentUrls;
 
     @Schema(hidden = true)
     private long postId;

--- a/src/main/java/flab/project/domain/post/model/BasicPost.java
+++ b/src/main/java/flab/project/domain/post/model/BasicPost.java
@@ -27,29 +27,14 @@ public class BasicPost extends BasePost {
     @Schema(example = "https://kr.object.ncloudstorage.com/postimage/~")
     private Set<String> preSignedImageUrls;
 
-    public BasicPost(AddBasicPostRequest addBasicPostRequest, long userId, Set<String> contentImageUrls) {
+    public BasicPost(AddBasicPostRequest addBasicPostRequest, long userId) {
         this.postId = addBasicPostRequest.getPostId();
         this.userId = userId;
         this.content = addBasicPostRequest.getContent();
         this.hashTagNames = addBasicPostRequest.getHashTagNames();
         this.postType = addBasicPostRequest.getPostType();
         this.createdAt = addBasicPostRequest.getCreatedAt();
-        this.contentImageUrls = contentImageUrls;
-        this.likeCount = 0;
-        this.commentCount = 0;
-        this.isLike = false;
-        this.isFollow = false;
-    }
-
-    public BasicPost(AddBasicPostRequest addBasicPostRequest, long userId, UploadedFileUrls uploadedFileUrls) {
-        this.postId = addBasicPostRequest.getPostId();
-        this.userId = userId;
-        this.content = addBasicPostRequest.getContent();
-        this.hashTagNames = addBasicPostRequest.getHashTagNames();
-        this.postType = addBasicPostRequest.getPostType();
-        this.createdAt = addBasicPostRequest.getCreatedAt();
-        this.contentImageUrls = uploadedFileUrls.getContentUrls();
-        this.preSignedImageUrls = uploadedFileUrls.getPreSignedUrls();
+        this.contentImageUrls = addBasicPostRequest.getContentUrls();
         this.likeCount = 0;
         this.commentCount = 0;
         this.isLike = false;

--- a/src/main/java/flab/project/domain/post/template/PostFacadeTemplate.java
+++ b/src/main/java/flab/project/domain/post/template/PostFacadeTemplate.java
@@ -1,10 +1,8 @@
 package flab.project.domain.post.template;
 
-import flab.project.domain.post.enums.PostType;
 import flab.project.domain.post.model.AddPostRequest;
 import flab.project.domain.post.model.BasePost;
 import flab.project.domain.feed.service.FanOutService;
-import flab.project.domain.post.model.UpdateBasicPostRequest;
 import flab.project.domain.post.service.PostHashTagService;
 import flab.project.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/flab/project/domain/user/controller/UserController.java
+++ b/src/main/java/flab/project/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import flab.project.config.baseresponse.SuccessResponse;
 import flab.project.domain.user.model.Profile;
 
 import flab.project.domain.user.model.ProfilePage;
+import flab.project.domain.user.model.UpdateProfileImageRequest;
 import flab.project.domain.user.model.UpdateProfileRequestDto;
 import flab.project.domain.user.facade.UserFacade;
 import flab.project.domain.user.service.UserService;
@@ -472,12 +473,13 @@ public class UserController {
     @PatchMapping(value = "/users/{userId}/profile-image")
     public SuccessResponse<UploadedFileUrl> updateProfileImage(
             @LoggedInUserId Long loggedInUserId,
-            @PathVariable("userId") @Positive long userIdFromPathVariable
+            @PathVariable("userId") @Positive long userIdFromPathVariable,
+            @RequestBody UpdateProfileImageRequest updateProfileImageRequest
     ) {
         AccessManagementUtil.assertUserIdOwner(loggedInUserId, userIdFromPathVariable);
 
-        UploadedFileUrl uploadedFileUrl = userFacade.updateProfileImage(loggedInUserId);
+        userFacade.updateProfileImage(loggedInUserId,updateProfileImageRequest.getContentUrl());
 
-        return new SuccessResponse<>(uploadedFileUrl);
+        return new SuccessResponse<>();
     }
 }

--- a/src/main/java/flab/project/domain/user/facade/UserFacade.java
+++ b/src/main/java/flab/project/domain/user/facade/UserFacade.java
@@ -1,25 +1,16 @@
 package flab.project.domain.user.facade;
 
-import flab.project.common.file_storage.FileUploader;
-import flab.project.common.file_storage.UploadedFileUrl;
 import flab.project.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import static flab.project.domain.file.enums.FileType.PROFILE_IMAGE;
 
 @RequiredArgsConstructor
 @Service
 public class UserFacade {
 
-    private final FileUploader fileUploader;
     private final UserService userService;
 
-    public UploadedFileUrl updateProfileImage(long userId) {
-        UploadedFileUrl uploadedFileUrl = fileUploader.generatePreSignedUrl(userId, PROFILE_IMAGE);
-
-        userService.updateProfileImage(userId, uploadedFileUrl.getContentUrl());
-
-        return uploadedFileUrl;
+    public void updateProfileImage(long userId, String contentUrl) {
+        userService.updateProfileImage(userId, contentUrl);
     }
 }

--- a/src/main/java/flab/project/domain/user/model/UpdateProfileImageRequest.java
+++ b/src/main/java/flab/project/domain/user/model/UpdateProfileImageRequest.java
@@ -1,0 +1,11 @@
+package flab.project.domain.user.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateProfileImageRequest {
+
+    private String contentUrl;
+}

--- a/src/test/java/flab/project/controller/BasicPostControllerTest.java
+++ b/src/test/java/flab/project/controller/BasicPostControllerTest.java
@@ -169,7 +169,6 @@ class BasicPostControllerTest {
         return AddBasicPostRequest.builder()
                 .content(postContent)
                 .hashTagNames(hashTagNames)
-                .imageCount(1)
                 .build();
     }
 

--- a/src/test/java/flab/project/controller/UserControllerTest.java
+++ b/src/test/java/flab/project/controller/UserControllerTest.java
@@ -352,7 +352,7 @@ class UserControllerTest {
         long userId = 1L;
         URL url = new URL("http", "host.domain", "file/path");
         UploadedFileUrl uploadedFileUrl = new UploadedFileUrl(url);
-        given(userFacade.updateProfileImage(userId)).willReturn(uploadedFileUrl);
+//        given(userFacade.updateProfileImage(userId)).willReturn(uploadedFileUrl);
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/flab/project/facade/BasicPostFacadeTest.java
+++ b/src/test/java/flab/project/facade/BasicPostFacadeTest.java
@@ -49,18 +49,16 @@ class BasicPostFacadeTest {
     @Test
     void addPost() throws MalformedURLException {
         // given
-        int imageCount = 1;
         long userId = 1L;
         AddBasicPostRequest validAddBasicPostRequest = AddBasicPostRequest.builder()
                 .content("게시물 내용입니다")
                 .hashTagNames(Set.of("#test1", "#test2"))
-                .imageCount(imageCount)
                 .build();
 
-        URL url = new URL("http", "host.domain", "file/path");
-        UploadedFileUrl uploadedFileUrl = new UploadedFileUrl(url);
-        UploadedFileUrls uploadedFileUrls = new UploadedFileUrls(Set.of(uploadedFileUrl));
-        given(fileUploader.generatePreSignedUrls(userId, imageCount, POST_IMAGE)).willReturn(uploadedFileUrls);
+//        URL url = new URL("http", "host.domain", "file/path");
+//        UploadedFileUrl uploadedFileUrl = new UploadedFileUrl(url);
+//        UploadedFileUrls uploadedFileUrls = new UploadedFileUrls(Set.of(uploadedFileUrl));
+//        given(fileUploader.generatePreSignedUrls(userId, imageCount, POST_IMAGE)).willReturn(uploadedFileUrls);
 
         // when
         basicPostFacade.addPost(userId, validAddBasicPostRequest);
@@ -69,7 +67,7 @@ class BasicPostFacadeTest {
         then(postService).should().addPost(userId, validAddBasicPostRequest);
         then(postHashTagService).should().saveAll(anyLong(), eq(validAddBasicPostRequest.getHashTagNames()));
         then(fanOutService).should().fanOut(userId, validAddBasicPostRequest.getPostId());
-        then(fileUploader).should().generatePreSignedUrls(userId, imageCount, POST_IMAGE);
+//        then(fileUploader).should().generatePreSignedUrls(userId, imageCount, POST_IMAGE);
         then(postImageService).should().saveAll(anyLong(), anySet());
     }
 

--- a/src/test/java/flab/project/facade/DebatePostFacadeTest.java
+++ b/src/test/java/flab/project/facade/DebatePostFacadeTest.java
@@ -81,7 +81,6 @@ class DebatePostFacadeTest {
         AddBasicPostRequest addBasicPostRequest = AddBasicPostRequest.builder()
                 .content("게시물 내용입니다")
                 .hashTagNames(Set.of("#test1", "#test2"))
-                .imageCount(imageCount)
                 .build();
 
         assertThatThrownBy(() -> debatePostFacade.addPost(userId, addBasicPostRequest))

--- a/src/test/java/flab/project/facade/PollPostFacadeTest.java
+++ b/src/test/java/flab/project/facade/PollPostFacadeTest.java
@@ -81,12 +81,10 @@ class PollPostFacadeTest {
     @Test
     void addPost_withAddBasicPostRequest() {
         long userId = 1L;
-        int imageCount=1;
 
         AddBasicPostRequest addBasicPostRequest = AddBasicPostRequest.builder()
                 .content("게시물 내용입니다")
                 .hashTagNames(Set.of("#test1", "#test2"))
-                .imageCount(imageCount)
                 .build();
 
         assertThatThrownBy(() -> pollPostFacade.addPost(userId, addBasicPostRequest))

--- a/src/test/java/flab/project/facade/UserFacadeTest.java
+++ b/src/test/java/flab/project/facade/UserFacadeTest.java
@@ -34,19 +34,15 @@ class UserFacadeTest {
     void updateProfileImage() throws MalformedURLException {
         // given
         long userId = 1L;
-        URL url = new URL("https", "kr.ncp.com", "/file/path");
-        UploadedFileUrl uploadedFileUrl = new UploadedFileUrl(url);
+        String contentUrl = "www.content.url";
 
-        given(fileUploader.generatePreSignedUrl(anyLong(), any(FileType.class)))
-                .willReturn(uploadedFileUrl);
         given(userService.updateProfileImage(anyLong(), anyString()))
                 .willReturn(true);
 
         // when
-        userFacade.updateProfileImage(userId);
+        userFacade.updateProfileImage(userId, contentUrl);
 
         // then
-        then(fileUploader).should().generatePreSignedUrl(userId, PROFILE_IMAGE);
-        then(userService).should().updateProfileImage(userId, "https://kr.ncp.com/file/path");
+        then(userService).should().updateProfileImage(userId, "www.content.url");
     }
 }

--- a/src/test/java/flab/project/mapper/PostMapperTest.java
+++ b/src/test/java/flab/project/mapper/PostMapperTest.java
@@ -81,7 +81,6 @@ class PostMapperTest {
         // given
         long postId = 1L;
         long writerId = 1L;
-        int imageCount = 1;
         String content = "content";
 
         AddBasicPostRequest basicPost = AddBasicPostRequest.builder()
@@ -89,7 +88,6 @@ class PostMapperTest {
                 .content(content)
                 .createdAt(Timestamp.valueOf(LocalDateTime.now()))
                 .hashTagNames(Set.of("hashTagName1"))
-                .imageCount(imageCount)
                 .build();
 
         postMapper.save(writerId, basicPost);
@@ -270,7 +268,6 @@ class PostMapperTest {
                 .content(content)
                 .createdAt(Timestamp.valueOf(LocalDateTime.now()))
                 .hashTagNames(Set.of("test1"))
-                .imageCount(1)
                 .build();
     }
 


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #255  

## 📃 작업 사항
- 기존 코드에서는 게시물 생성 / 프로필 이미지 수정 API가 호출되는 시점에 presignedURL을 발급 받으면서 DB에 미리 이미지를 수정했음.
- 하지만, DB가 변경되고 나서 실제로 유저가 이미지 업로드/수정을 하지 않거나 실패했을 경우를 대비하여 로직을 변경
- S3에 이미지 업로드 부터 먼저 진행한 후, 이미지 업로드에 성공하면 그때, DB반영을 진행
