### PR TITLE
[Fix] 부모 댓글 조회 쿼리문 수정

### DIFF
--- a/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
+++ b/src/main/resources/mapper/flab/project/mapper/comment-mapper.xml
@@ -66,7 +66,7 @@
     SELECT EXISTS (
              SELECT 1
              FROM COMMENT
-             WHERE parent_id = #{parentId}
+             WHERE comment_id = #{parentId}
              )
   </select>
 


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #257 

## 📃 작업 사항
- 대댓글 작성 시, 부모 댓글이 존재함에도 불구하고 "존재하지 않는 댓글입니다"반환 버그 수정
